### PR TITLE
Bme680 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Particle meter (PM) sensor manager for multiple (PM) sensors: Honeywell, Plantow
 - [x] Added old DHT sensors 
 - [x] Added CO2 sensors: MHZ19, SCD30, CM1106
 - [x] Added SDS011 particle metter
-- [ ] BME680 support (from TTGO-T7 CanAirIO version)
+- [x] BME680 support (from TTGO-T7 CanAirIO version)
+- [ ] IAQ indicator from BME680 Bosch library
 
 ## Usage
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,6 +19,7 @@ lib_deps =
     adafruit/Adafruit Unified Sensor @ 1.1.4
     adafruit/Adafruit AM2320 sensor library @ 1.1.4
     adafruit/Adafruit BME280 Library @ 2.1.2
+    Adafruit BME680 Library@1.0.7
     adafruit/Adafruit BusIO @ 1.6.0
     adafruit/Adafruit SHT31 Library @ 2.0.0
     enjoyneering/AHT10 @ ^1.1.0

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -4,6 +4,7 @@
 #include <AHT10.h>
 #include <Adafruit_AM2320.h>
 #include <Adafruit_BME280.h>
+#include <Adafruit_BME680.h>
 #include <Adafruit_SHT31.h>
 #include <Adafruit_Sensor.h>
 #include <MHZ19.h>
@@ -38,12 +39,14 @@ using namespace std;
 #define DHT_SENSOR_PIN 17
 #else
 #define DHT_SENSOR_PIN 23            // DHT default pin
-#define DHT_SENSOR_TYPE DHT_TYPE_22  // DHT sensor type
 #define PMS_RX 17  // config for D1MIN1 board (Default for main ESP32 dev boards)
 #define PMS_TX 16
 #endif
 
-// Sensor read retry. 
+// DHT sensor type
+#define DHT_SENSOR_TYPE DHT_TYPE_22  
+
+// Read UART sensor retry. 
 #define SENSOR_RETRY 1000         // Max Serial characters
 
 // Sensirion SPS30 sensor
@@ -72,10 +75,17 @@ class Sensors {
 
     /// Sensirion library
     SPS30 sps30;
-    // Humidity sensor
+
+    /*****************************************
+     * I2C sensors:
+     ****************************************/
+
+    // AM2320 (Humidity and temperature)
     Adafruit_AM2320 am2320;
-    // BME280 I2C
-    Adafruit_BME280 bme;
+    // BME280 (Humidity, Pressure, Altitude and Temperature)
+    Adafruit_BME280 bme280;
+    // BME680 (Humidity, Gas, IAQ, Pressure, Altitude and Temperature)
+    Adafruit_BME680 bme680; 
     // AHT10
     AHT10 aht10;
     // SHT31
@@ -167,6 +177,9 @@ class Sensors {
 
     void bme280Init();
     void bme280Read();
+
+    void bme680Init();
+    void bme680Read();
 
     void aht10Init();
     void aht10Read();


### PR DESCRIPTION
- [x] fixed issue with TTGO T-Display on DHT22 sensor type default pin
- [x] Added Adafruit BME680 library and basic implementation
- [x] Tested on real device (TTGO-Tdisplay BME680 (i2c) and Panasonic PM2.5 in UART) 
- [ ] Add IAQ indicator 