### PR TITLE
added SPS30 via i2c support

### DIFF
--- a/examples/sps30i2c/sps30i2c.cpp
+++ b/examples/sps30i2c/sps30i2c.cpp
@@ -1,7 +1,7 @@
 /**
  * @file main.cpp
  * @author Antonio Vanegas @hpsaturn
- * @date June 2018 - 2020
+ * @date June 2018 - 2021
  * @brief Particle meter sensor tests
  * @license GPL3
  * 
@@ -13,6 +13,10 @@
  * 
  * CanAirIO project:
  * https://canair.io
+ * 
+ * CanAirIO Docs:
+ * https://canair.io/docs
+ * 
  */
 
 #include <Arduino.h>
@@ -44,7 +48,7 @@ void setup() {
     sensors.setOnDataCallBack(&onSensorDataOk);     // all data read callback
     sensors.setOnErrorCallBack(&onSensorDataError); // [optional] error callback
     sensors.setDebugMode(false);                    // [optional] debug mode
-    sensors.detectI2COnly(true);                    // skip UART detection
+    sensors.detectI2COnly(true);                    // [optional] skip UART detection
 
     sensors.init();  
 

--- a/examples/sps30i2c/sps30i2c.cpp
+++ b/examples/sps30i2c/sps30i2c.cpp
@@ -35,17 +35,18 @@ void onSensorDataError(const char * msg){
 
 void setup() {
     Serial.begin(115200);
-    delay(200);
-    Serial.println("\n== Sensor test setup ==\n");
+    delay(1000);
 
+    Serial.println("\n== Sensor test setup ==\n");
     Serial.println("-->[SETUP] Detecting sensors..");
 
     sensors.setSampleTime(5);                       // config sensors sample time interval
     sensors.setOnDataCallBack(&onSensorDataOk);     // all data read callback
     sensors.setOnErrorCallBack(&onSensorDataError); // [optional] error callback
-    sensors.setDebugMode(true);                     // [optional] debug mode
+    sensors.setDebugMode(false);                    // [optional] debug mode
+    sensors.detectI2COnly(true);                    // skip UART detection
 
-    sensors.init(sensors.Auto);
+    sensors.init();  
 
     if(sensors.isPmSensorConfigured())
         Serial.println("-->[SETUP] Sensor configured: " + sensors.getPmDeviceSelected());

--- a/examples/sps30i2c/sps30i2c.cpp
+++ b/examples/sps30i2c/sps30i2c.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file main.cpp
+ * @author Antonio Vanegas @hpsaturn
+ * @date June 2018 - 2020
+ * @brief Particle meter sensor tests
+ * @license GPL3
+ * 
+ * Full documentation:
+ * https://github.com/kike-canaries/canairio_sensorlib#canairio-air-quality-sensors-library
+ * 
+ * Full implementation for WiFi and Bluetooth Air Quality fixed and mobile station:
+ * https://github.com/kike-canaries/canairio_firmware#canairio-firmware
+ * 
+ * CanAirIO project:
+ * https://canair.io
+ */
+
+#include <Arduino.h>
+#include <Sensors.hpp>
+
+void onSensorDataOk() {
+    Serial.print ("-->[MAIN] PM1.0: "+sensors.getStringPM1());
+    Serial.print (" PM2.5: " + sensors.getStringPM25());
+    Serial.print (" PM10: " + sensors.getStringPM10());
+    Serial.println (" PM1: " + sensors.getStringPM1());
+}
+
+void onSensorDataError(const char * msg){ 
+    Serial.println(msg);
+}
+
+/******************************************************************************
+*  M A I N
+******************************************************************************/
+
+void setup() {
+    Serial.begin(115200);
+    delay(200);
+    Serial.println("\n== Sensor test setup ==\n");
+
+    Serial.println("-->[SETUP] Detecting sensors..");
+
+    sensors.setSampleTime(5);                       // config sensors sample time interval
+    sensors.setOnDataCallBack(&onSensorDataOk);     // all data read callback
+    sensors.setOnErrorCallBack(&onSensorDataError); // [optional] error callback
+    sensors.setDebugMode(true);                     // [optional] debug mode
+
+    sensors.init(sensors.Auto);
+
+    if(sensors.isPmSensorConfigured())
+        Serial.println("-->[SETUP] Sensor configured: " + sensors.getPmDeviceSelected());
+
+    delay(500);
+}
+
+uint64_t counter = 0;
+
+void loop() {
+
+    sensors.loop();  // read sensor data and showed it
+    
+}

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "CanAirIO Air Quality Sensors Library",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "homepage":"https://canair.io",
   "keywords": 
   [ 
@@ -68,14 +68,14 @@
     {"name":"Adafruit Unified Sensor", "owner":"adafruit", "version":"1.1.4"},
     {"name":"Adafruit AM2320 sensor library", "owner":"adafruit", "version":"1.1.4"},
     {"name":"sps30", "owner":"paulvha","version":"1.4.9"},
-    {"name":"Adafruit BME280 Library", "owner":"adafruit","version":"2.1.2"},
+    {"name":"Adafruit BME280 Library", "owner":"adafruit","version":"2.1.4"},
     {"name":"AHT10", "owner":"enjoyneering","version":"1.1.0"},
-    {"name":"Adafruit BusIO", "owner":"adafruit","version":"1.6.0"},
+    {"name":"Adafruit BusIO", "owner":"adafruit","version":"1.7.3"},
     {"name":"Adafruit SHT31 Library", "owner":"adafruit","version":"2.0.0"},
     {"name":"DHT_nonblocking", "version":"https://github.com/hpsaturn/DHT_nonblocking/archive/master.zip"},
     {"name":"MH-Z19", "owner":"wifwaf", "version":"1.5.3"},
     {"name":"SparkFun SCD30 Arduino Library","owner":"sparkfun","version":"1.0.10"},
     {"name":"CM1106_UART", "version":"https://github.com/hpsaturn/CM1106_UART.git"},
-    {"name":"Adafruit BME680 Library","owner":"adafruit","version":"1.0.7"}
+    {"name":"Adafruit BME680 Library","owner":"adafruit","version":"2.0.0"}
   ]
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CanAirIO Air Quality Sensors Library
-version=0.2.1
+version=0.2.2
 author=@hpsaturn, CanAirIO project <info@canair.io>
 maintainer=Antonio Vanegas <hpsaturn@gmail.com>
 url=https://github.com/kike-canaries/canairio_sensorlib

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,9 +18,9 @@ build_flags =
 lib_deps =
     adafruit/Adafruit Unified Sensor @ 1.1.4
     adafruit/Adafruit AM2320 sensor library @ 1.1.4
-    adafruit/Adafruit BME280 Library @ 2.1.2
+    adafruit/Adafruit BME280 Library @ 2.1.4
     adafruit/Adafruit BME680 Library@2.0.0
-    adafruit/Adafruit BusIO @ 1.6.0
+    adafruit/Adafruit BusIO @ 1.7.3
     adafruit/Adafruit SHT31 Library @ 2.0.0
     enjoyneering/AHT10 @ ^1.1.0
     https://github.com/hpsaturn/DHT_nonblocking.git

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ upload_speed = 1500000
 monitor_speed = 115200
 monitor_filters = time
 build_flags =
-    -D SRC_REV=273
+    -D SRC_REV=301
     -D CORE_DEBUG_LEVEL=0
 lib_deps =
     adafruit/Adafruit Unified Sensor @ 1.1.4

--- a/platformio.ini
+++ b/platformio.ini
@@ -58,3 +58,9 @@ src_filter = -<*> +<platformio/>
 [env:esp8266]
 extends = esp8266_common
 src_filter = -<*> +<platformio/>
+
+[env:esp32sps30i2c]
+extends = esp32_common
+src_filter = -<*> +<sps30i2c/>
+
+

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -223,8 +223,8 @@ bool Sensors::pmGenericRead() {
     if (txtMsg[0] == 66) {
         if (txtMsg[1] == 77) {
             DEBUG("-->[PMS-HPMA] read > done!");
-            pm25 = txtMsg[6] * 256 + byte(txtMsg[7]);
-            pm10 = txtMsg[8] * 256 + byte(txtMsg[9]);
+            pm25 = txtMsg[6] * 256 + (char)(txtMsg[7]);
+            pm10 = txtMsg[8] * 256 + (char)(txtMsg[9]);
             if (pm25 > 1000 && pm10 > 1000) {
                 onSensorError("-->[E][PMSENSOR] out of range pm25 > 1000");
             } else
@@ -245,9 +245,9 @@ bool Sensors::pmPanasonicRead() {
     String txtMsg = hwSerialRead(lenght_buffer);
     if (txtMsg[0] == 02) {
         DEBUG("-->[PANASONIC] read > done!");
-        pm1 = txtMsg[2] * 256 + byte(txtMsg[1]);
-        pm25 = txtMsg[6] * 256 + byte(txtMsg[5]);
-        pm10 = txtMsg[10] * 256 + byte(txtMsg[9]);
+        pm1 = txtMsg[2] * 256 + (char)(txtMsg[1]);
+        pm25 = txtMsg[6] * 256 + (char)(txtMsg[5]);
+        pm10 = txtMsg[10] * 256 + (char)(txtMsg[9]);
         if (pm25 > 2000 && pm10 > 2000) {
             onSensorError("-->[E][PMSENSOR] out of range pm25 > 2000");
         } else
@@ -268,8 +268,8 @@ bool Sensors::pmSDS011Read() {
     if (txtMsg[0] == 170) {
         if (txtMsg[1] == 192) {
             DEBUG("-->[SDS011] read > done!");
-            pm25 = (txtMsg[3] * 256 + byte(txtMsg[2])) / 10;
-            pm10 = (txtMsg[5] * 256 + byte(txtMsg[4])) / 10;
+            pm25 = (txtMsg[3] * 256 + (char)(txtMsg[2])) / 10;
+            pm10 = (txtMsg[5] * 256 + (char)(txtMsg[4])) / 10;
             if (pm25 > 1000 && pm10 > 1000) {
                 onSensorError("-->[E][PMSENSOR] out of range pm25 > 1000");
             } else

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -64,7 +64,7 @@ void Sensors::init(int pms_type, int pms_rx, int pms_tx) {
     Wire.begin(25,26);  // M5CoreInk hat pines (header on top)
 #endif
     Wire.begin();
-
+    
     DEBUG("-->[SENSORS] try to load I2C sensor..");
     sps30I2CInit();
     am2320Init();

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -316,7 +316,7 @@ bool Sensors::sps30Read() {
                 DEBUG("-->[E][SPS30] Error during reading values: ", String(ret).c_str());
                 return false;
             }
-            delay(1000);
+            delay(500);
         } else if (ret != ERR_OK) {
             sps30ErrToMess((char *)"-->[W][SPS30] Error during reading values: ", ret);
             return false;
@@ -745,7 +745,6 @@ bool Sensors::sps30I2CInit() {
 
     // start measurement
     if (sps30.start()) {
-        delay(100);
         sps30Read();
         DEBUG("-->[SPS30] Measurement OK");
         device_selected = "SENSIRION";
@@ -956,7 +955,7 @@ bool Sensors::serialInit(int pms_type, long speed_baud, int pms_rx, int pms_tx) 
             break;
     }
 
-    delay(100);
+    delay(10);
     return true;
 }
 

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -11,8 +11,8 @@ DHT_nonblocking dht_sensor(DHT_SENSOR_PIN, DHT_SENSOR_TYPE);
  * All sensors are read here, please call it on main loop.
  */
 void Sensors::loop() {
-    static uint_fast64_t pmLoopTimeStamp = 0;                 // timestamp for sensor loop check data
-    if ((millis() - pmLoopTimeStamp > sample_time * 1000)) {  // sample time for each capture
+    static uint32_t pmLoopTimeStamp = 0;                 // timestamp for sensor loop check data
+    if ((millis() - pmLoopTimeStamp > sample_time * (uint32_t)1000)) {  // sample time for each capture
         pmLoopTimeStamp = millis();
         dataReady = false;
         dataReady = pmSensorRead();

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -149,6 +149,8 @@ class Sensors {
 
     void setCO2RecalibrationFactor(int ppmValue);
 
+    void detectI2COnly(bool enable);
+
    private:
     /// DHT library
     uint32_t delayMS;
@@ -177,6 +179,8 @@ class Sensors {
     uint16_t CO2;         // CO2 in ppm
     float CO2humi = 0.0;  // temperature of the CO2 sensor
     float CO2temp = 0.0;  // temperature of the CO2 sensor
+
+    bool _only_i2c_sensors;
 
     void am2320Init();
     void am2320Read();

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -215,13 +215,14 @@ class Sensors {
     bool CO2Mhz19Init();
     bool CO2CM1106Init();
 
-    bool pmSensirionInit();
-    bool pmSensirionRead();
-    void pmSensirionErrtoMess(char *mess, uint8_t r);
-    void pmSensirionErrorloop(char *mess, uint8_t r);
-    void pmSensirionDeviceInfo();
+    bool sps30I2CInit();
+    bool sps30UARTInit();
+    bool sps30Read();
+    void sps30ErrToMess(char *mess, uint8_t r);
+    void sps30Errorloop(char *mess, uint8_t r);
+    void sps30DeviceInfo();
 
-    void onPmSensorError(const char *msg);
+    void onSensorError(const char *msg);
 
     bool serialInit(int pms_type, long speed_baud, int pms_rx, int pms_tx);
     String hwSerialRead(unsigned int lenght_buffer);


### PR DESCRIPTION
- [x] SPS30 i2c init flow with backward compatibility (UART)
- [x] some method names refactored
- [x] fixed some possible issues on SPS30 UART init  
- [x] added example for only test i2c communication with SPS30 sensor 