### PR TITLE
Sngcja5l i2c

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,21 +41,6 @@ NOTE: Panasonic via UART in ESP8266 maybe needs select in detection
 
 NOTE: DHT22 is supported but is not recommended
 
-## TODO
-
-- [x] Auto detection for UART sensors (Honeywell, Panasonic and Plantower)
-- [x] Added SPS30 library with auto UART detection
-- [x] Disable/enable logs (debug mode flag)
-- [x] Added bme280, aht10, sht31, am2320 i2c sensors
-- [x] Exposed public sub-libraries objects, sps30, aht10, etc.
-- [x] Added old DHT sensors 
-- [x] Added CO2 sensors: MHZ19, SCD30, CM1106 via UART
-- [x] Added SDS011 particle metter
-- [x] BME680 support (from TTGO-T7 CanAirIO version)
-- [x] Added Sensirion SPS30 and Panasonic SN-GCJA5 via i2c
-- [x] Enable/Disable UART detection for force only i2c
-- [ ] IAQ indicator from BME680 Bosch library
-
 
 ## Usage
 
@@ -92,7 +77,9 @@ void setup() {
     sensors.setSampleTime(5);                       // config sensors sample time interval
     sensors.setOnDataCallBack(&onSensorDataOk);     // all data read callback
     sensors.setOnErrorCallBack(&onSensorDataError); // [optional] error callback
-    sensors.setDebugMode(true);                     // [optional] debug mode
+    sensors.setSampleTime(15);                      // [optional] sensors sample time (default 5s)
+    sensors.setDebugMode(false);                    // [optional] debug mode enable/disable
+    sensors.detectI2COnly(true);                    // [optional] force to only i2c sensors
     sensors.init();                                 // start all sensors and
                                                     // force to try autodetection,
                                                     // you can try to select one:
@@ -131,15 +118,41 @@ On your serial monitor you should have something like that:
 -->[MAIN] PM1.0: 002 PM2.5: 002 PM10: 002
 ```
 
-## Demo
+# Demo
 
 [![CanAirIO auto configuration demo](https://img.youtube.com/vi/hmukAmG5Eec/0.jpg)](https://www.youtube.com/watch?v=hmukAmG5Eec)
 
 CanAirIO sensorlib auto configuration demo on [Youtube](https://www.youtube.com/watch?v=hmukAmG5Eec)
 
----
 
-## Examples
+# Wiring
+
+The current version of library supports 3 kinds of wiring connection, UART, i2c and TwoWire, in the main boards the library using the defaults pins of each board, but in some special cases the pins are:
+
+### UART
+
+The library has [pre-defined some UART pin configs](https://github.com/kike-canaries/canairio_sensorlib/blob/master/src/Sensors.hpp#L19-L52), these are selected on compiling time. Maybe you don't need change anything with your board.  
+
+Also you can define the UART pins in the init() method, please see below.  
+
+#### Custom UART RX/TX:
+
+You can pass the custom pins if it isn't autodected:
+
+```cpp
+sensors.init(sensors.Auto,RX,TX); // custom RX, custom TX pines.
+```
+
+### I2C (recommended)
+
+We are using the default pins for each board, some times it's pins are 21,22, please check your board schematic.
+
+### TwoWire (deprecated soon)
+
+For now we are using it only for DHT sensors in PIN 23. For more info please review the next lines [here](https://github.com/kike-canaries/canairio_sensorlib/blob/master/src/Sensors.hpp#L19-L52).
+
+
+# Examples
 
 ### PlatformIO (recommended)
 
@@ -185,31 +198,21 @@ arduino-cli upload --fqbn esp32:esp32:lolin32:UploadSpeed=115200 -p /dev/ttyUSB0
 
 where `basic` is the basic example on examples directory.
 
-# Wiring
+# TODO
 
-The current version of library supports 3 kinds of wiring connection, UART, i2c and TwoWire, in the main boards the library using the defaults pins of each board, but in some special cases the pins are:
+- [x] Auto detection for UART sensors (Honeywell, Panasonic and Plantower)
+- [x] Added SPS30 library with auto UART detection
+- [x] Disable/enable logs (debug mode flag)
+- [x] Added bme280, aht10, sht31, am2320 i2c sensors
+- [x] Exposed public sub-libraries objects, sps30, aht10, etc.
+- [x] Added old DHT sensors 
+- [x] Added CO2 sensors: MHZ19, SCD30, CM1106 via UART
+- [x] Added SDS011 particle metter
+- [x] BME680 support (from TTGO-T7 CanAirIO version)
+- [x] Added Sensirion SPS30 and Panasonic SN-GCJA5 via i2c
+- [x] Enable/Disable UART detection for force only i2c
+- [ ] IAQ indicator from BME680 Bosch library
 
-### UART
-
-The library has [pre-defined some UART pin configs](https://github.com/kike-canaries/canairio_sensorlib/blob/master/src/Sensors.hpp#L19-L52), these are selected on compiling time. Maybe you don't need change anything with your board.  
-
-Also you can define the UART pins in the init() method, please see below.  
-
-#### Custom UART RX/TX:
-
-You can pass the custom pins if it isn't autodected:
-
-```cpp
-sensors.init(sensors.Auto,RX,TX); // custom RX, custom TX pines.
-```
-
-### I2C (recommended)
-
-We are using the default pins for each board, some times it's pins are 21,22, please check your board schematic.
-
-### TwoWire (deprecated soon)
-
-For now we are using it only for DHT sensors in PIN 23. For more info please review the next lines [here](https://github.com/kike-canaries/canairio_sensorlib/blob/master/src/Sensors.hpp#L19-L52).
 
 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # CanAirIO Air Quality Sensors Library
 
-Particle meter (PM) sensor manager for multiple (PM) sensors: Honeywell, Plantower, Panasonic, Sensirion, etc, CO2 sensors also it handling others environment sensors like AM2320 sensor.
+Particle meter (PM) sensor manager for multiple (PM) sensors: Honeywell, Plantower, Panasonic, Sensirion, etc and CO2 sensors. Also it handling others environment sensors.
 
 # Supported sensors
 
@@ -16,7 +16,6 @@ Particle meter (PM) sensor manager for multiple (PM) sensors: Honeywell, Plantow
 | Plantower models    | Yes | --- | Auto | STABLE |
 | Nova SDS011         | Yes | --- | Auto | STABLE |
 | Sensirion SPS30     | Yes | Yes | Select / Auto | STABLE |
-| | | | |
 
 NOTE: Panasonic via UART in ESP8266 maybe needs select in detection
 
@@ -27,7 +26,6 @@ NOTE: Panasonic via UART in ESP8266 maybe needs select in detection
 | Sensirion SCD30    | --- | Yes | Auto | STABLE |
 | MHZ19      | Yes | --- | Select | TESTING |
 | CMS1106    | Yes | --- | Select | TESTING |
-| | | | |
 
 
 ### Environmental sensors
@@ -40,7 +38,6 @@ NOTE: Panasonic via UART in ESP8266 maybe needs select in detection
 | BME280      | i2c |  Auto | STABLE |
 | BME680      | i2c |  Auto | STABLE |
 | DHT2x       | TwoWire |  Auto | DEPRECATED |
-| | | | |
 
 NOTE: DHT22 is supported but is not recommended
 

--- a/README.md
+++ b/README.md
@@ -3,20 +3,62 @@
 
 # CanAirIO Air Quality Sensors Library
 
-Particle meter (PM) sensor manager for multiple (PM) sensors: Honeywell, Plantower, Panasonic, Sensirion, etc, also it handling others like AM2320 sensor.
+Particle meter (PM) sensor manager for multiple (PM) sensors: Honeywell, Plantower, Panasonic, Sensirion, etc, CO2 sensors also it handling others environment sensors like AM2320 sensor.
 
-## Features
+# Supported sensors
 
-- [x] Auto detection for Generic sensors (Honeywell, Panasonic and Plantower sensors)
-- [x] Implemented `Sensirion` autodection flow (for original library)
+### PM sensors
+
+| Sensor model  | UART  | I2C  | Detection mode | Status |  
+|:----------------------- |:-----:|:-----:|:-------:|:----------:|
+| Honeywell HPMA115S0 | Yes | --- | Auto | DEPRECATED |
+| Panasonic SN-GCJA5L | Yes | Yes | Auto | STABLE |
+| Plantower models    | Yes | --- | Auto | STABLE |
+| Nova SDS011         | Yes | --- | Auto | STABLE |
+| Sensirion SPS30     | Yes | Yes | Select / Auto | STABLE |
+| | | | |
+
+NOTE: Panasonic via UART in ESP8266 maybe needs select in detection
+
+### CO2 sensors
+
+| Sensor model  | UART  | i2c  | Detection mode | Status |  
+|:----------------------- |:-----:|:-----:|:-------:|:----------:|
+| Sensirion SCD30    | --- | Yes | Auto | STABLE |
+| MHZ19      | Yes | --- | Select | TESTING |
+| CMS1106    | Yes | --- | Select | TESTING |
+| | | | |
+
+
+### Environmental sensors
+
+| Sensor model  | Protocol  | Detection mode | Status |  
+|:----------------------- |:-----:|:-------:|:----------:|
+| AM2320      | i2c |  Auto | STABLE |
+| SHT31       | i2c |  Auto | STABLE |
+| AHT10       | i2c |  Auto | STABLE |
+| BME280      | i2c |  Auto | STABLE |
+| BME680      | i2c |  Auto | STABLE |
+| DHT2x       | TwoWire |  Auto | DEPRECATED |
+| | | | |
+
+NOTE: DHT22 is supported but is not recommended
+
+## TODO
+
+- [x] Auto detection for UART sensors (Honeywell, Panasonic and Plantower)
+- [x] Added SPS30 library with auto UART detection
 - [x] Disable/enable logs (debug mode flag)
 - [x] Added bme280, aht10, sht31, am2320 i2c sensors
 - [x] Exposed public sub-libraries objects, sps30, aht10, etc.
 - [x] Added old DHT sensors 
-- [x] Added CO2 sensors: MHZ19, SCD30, CM1106
+- [x] Added CO2 sensors: MHZ19, SCD30, CM1106 via UART
 - [x] Added SDS011 particle metter
 - [x] BME680 support (from TTGO-T7 CanAirIO version)
+- [x] Added Sensirion SPS30 and Panasonic SN-GCJA5 via i2c
+- [x] Enable/Disable UART detection for force only i2c
 - [ ] IAQ indicator from BME680 Bosch library
+
 
 ## Usage
 
@@ -146,27 +188,14 @@ arduino-cli upload --fqbn esp32:esp32:lolin32:UploadSpeed=115200 -p /dev/ttyUSB0
 
 where `basic` is the basic example on examples directory.
 
-## Wiring
+# Wiring
 
 The current version of library supports 3 kinds of wiring connection, UART, i2c and TwoWire, in the main boards the library using the defaults pins of each board, but in some special cases the pins are:
 
 ### UART
 
-```cpp
-#ifdef WEMOSOLED
-#define PMS_RX 13  // config for Wemos board & TTGO18650
-#define PMS_TX 15  // some old TTGO18650 have PMS_RX 18 & PMS_TX 17
-#elif HELTEC
-#define PMS_RX 17  // config for Heltec board, ESP32Sboard & ESPDUINO-32
-#define PMS_TX 18  // some old ESP32Sboard have PMS_RX 27 & PMS_TX 25
-#elif TTGO_TQ
-#define PMS_RX 13  // config for TTGO_TQ board
-#define PMS_TX 18
-#else
-#define PMS_RX 17  // config for D1MIN1 board (Default for main ESP32 dev boards)
-#define PMS_TX 16
-#endif
-```
+The library has [pre-defined some UART pin configs](https://github.com/kike-canaries/canairio_sensorlib/blob/master/src/Sensors.hpp#L19-L52), these are selected on compiling time. Maybe you don't need change anything with your board.  
+
 Also you can define the UART pins in the init() method, please see below.  
 
 #### Custom UART RX/TX:
@@ -177,19 +206,18 @@ You can pass the custom pins if it isn't autodected:
 sensors.init(sensors.Auto,RX,TX); // custom RX, custom TX pines.
 ```
 
-
-
-### i2c (recommended)
+### I2C (recommended)
 
 We are using the default pins for each board, some times it's pins are 21,22, please check your board schematic.
 
-### TwoWire
+### TwoWire (deprecated soon)
 
-For now we are using it only for DHT sensors in PIN 23. For more info please review the next lines [here](https://github.com/kike-canaries/canairio_sensorlib/blob/01ae9e976aa2985bb66856c0d6fae2a03100f552/src/Sensors.hpp#L16-L45).
+For now we are using it only for DHT sensors in PIN 23. For more info please review the next lines [here](https://github.com/kike-canaries/canairio_sensorlib/blob/master/src/Sensors.hpp#L19-L52).
 
 
----
 
-## Credits
+# Credits
 
 Thanks to all collaborators and [CanAirIO](https://canair.io) community for testing and reports.
+
+---

--- a/examples/advanced_sensirion/sensirion.ino
+++ b/examples/advanced_sensirion/sensirion.ino
@@ -45,7 +45,8 @@ void setup() {
     sensors.setOnErrorCallBack(&onSensorDataError); // [optional] error callback
     sensors.setDebugMode(true);                     // [optional] debug mode
 
-    sensors.init(sensors.Sensirion);
+    sensors.init(sensors.Sensirion);                // forced Sensirion via UART.
+                                                    // for i2c only leave empty this parameter
 
     if(sensors.isPmSensorConfigured())
         Serial.println("-->[SETUP] Sensor configured: " + sensors.getPmDeviceSelected());

--- a/examples/basic/basic.ino
+++ b/examples/basic/basic.ino
@@ -35,13 +35,17 @@ void setup() {
     sensors.setOnErrorCallBack(&onSensorDataError); // [optional] error callback
     sensors.setDebugMode(false);                    // [optional] debug mode
 
-    // sensors.init();                              // Auto detection of PM sensors (Honeywell, Plantower)
-    // sensors.init(sensors.Auto);                  // Auto detection of PM sensors (Honeywell, Plantower)
+    // sensors.init();                              // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
+    // sensors.init(sensors.Auto);                  // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
     // sensors.init(sensors.Panasonic);             // Force detection to Panasonic sensor
     // sensors.init(sensors.Sensirion);             // Force detection to Sensirion sensor
+    // sensors.init(sensors.Mhz19);                 // Force detection to Mhz14 or Mhz19 CO2 sensor
+    // sensors.init(sensors.SDS011);                // Force detection to SDS011 sensor
+    // sensors.init(sensors.CM1006);                // Force detection to CM1106 CO2 sensor
     // sensors.init(sensors.Auto,mRX,mTX);          // Auto detection and custom RX, TX pines
+    // sensors.init(sensors.Auto,PMS_RX,PMS_TX);    // Auto detection, custom RX,TX and custom DHT config
 
-    sensors.init(sensors.Sensirion);                // Force detection to Sensirion sensor
+    sensors.init();                                 // Force detection to Sensirion sensor
 
     if(sensors.isPmSensorConfigured())
         Serial.println("-->[SETUP] Sensor configured: " + sensors.getPmDeviceSelected());

--- a/examples/basic_esp8266/basic_esp8266.ino
+++ b/examples/basic_esp8266/basic_esp8266.ino
@@ -43,13 +43,17 @@ void setup() {
     sensors.setSampleTime(5);                       // config sensors sample time interval
     sensors.setOnDataCallBack(&onSensorDataOk);     // all data read callback
     sensors.setOnErrorCallBack(&onSensorDataError); // [optional] error callback
-    sensors.setDebugMode(true);                    // [optional] debug mode
+    sensors.setDebugMode(true);                     // [optional] debug mode
 
     // sensors.init();                              // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
     // sensors.init(sensors.Auto);                  // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
     // sensors.init(sensors.Panasonic);             // Force detection to Panasonic sensor
     // sensors.init(sensors.Sensirion);             // Force detection to Sensirion sensor
+    // sensors.init(sensors.Mhz19);                 // Force detection to Mhz14 or Mhz19 CO2 sensor
+    // sensors.init(sensors.SDS011);                // Force detection to SDS011 sensor
+    // sensors.init(sensors.CM1006);                // Force detection to CM1106 CO2 sensor
     // sensors.init(sensors.Auto,mRX,mTX);          // Auto detection and custom RX, TX pines
+    // sensors.init(sensors.Auto,PMS_RX,PMS_TX);    // Auto detection, custom RX,TX and custom DHT config
 
     sensors.init(sensors.Panasonic, 5, 6);          // Panasonic sensor with ESP8266 software serial pines
 

--- a/examples/co2_cm1106/co2_cm1106.ino
+++ b/examples/co2_cm1106/co2_cm1106.ino
@@ -47,14 +47,8 @@ void setup() {
     sensors.setOnErrorCallBack(&onSensorDataError);  // [optional] error callback
     sensors.setDebugMode(true);                      // [optional] debug mode
 
-    // sensors.init();                                    // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
-    // sensors.init(sensors.Auto);                        // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
-    // sensors.init(sensors.Panasonic);                   // Force detection to Panasonic sensor
-    // sensors.init(sensors.Sensirion);                   // Force detection to Sensirion sensor
-    // sensors.init(sensors.Mhz19);                       // Force detection to Mhz14 or Mhz19 CO2 sensor
-    // sensors.init(sensors.CM1006);                      // Force detection to CM1106 CO2 sensor
-    // sensors.init(sensors.Auto,mRX,mTX);                // Auto detection and custom RX, TX pines
-    // sensors.init(sensors.Auto,PMS_RX,PMS_TX); // Auto detection, custom RX,TX and custom DHT config
+    // sensors.setCO2RecalibrationFactor(400);       // calibration method (in outdoors)
+    
     sensors.init(sensors.CM1106);
 
     if (sensors.isPmSensorConfigured())

--- a/examples/co2_mhz19/co2_mhz19.ino
+++ b/examples/co2_mhz19/co2_mhz19.ino
@@ -49,12 +49,8 @@ void setup() {
     sensors.setOnErrorCallBack(&onSensorDataError);  // [optional] error callback
     sensors.setDebugMode(true);                      // [optional] debug mode
 
-    // sensors.init();                                    // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
-    // sensors.init(sensors.Auto);                        // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
-    // sensors.init(sensors.Panasonic);                   // Force detection to Panasonic sensor
-    // sensors.init(sensors.Sensirion);                   // Force detection to Sensirion sensor
-    // sensors.init(sensors.Auto,mRX,mTX);                // Auto detection and custom RX, TX pines
-    // sensors.init(sensors.Auto,PMS_RX,PMS_TX); // Auto detection, custom RX,TX and custom DHT config
+    // sensors.setCO2RecalibrationFactor(400);       // calibration method (in outdoors)
+
     sensors.init(sensors.Mhz19);
 
     if (sensors.isPmSensorConfigured())

--- a/examples/co2_scd30/co2_scd30.ino
+++ b/examples/co2_scd30/co2_scd30.ino
@@ -19,11 +19,7 @@
 #include <Sensors.hpp>
 
 void onSensorDataOk() {
-    Serial.print("-->[MAIN] PM1: " + sensors.getStringPM1());
-    Serial.print(" PM2.5: " + sensors.getStringPM25());
-    Serial.print(" PM10: " + sensors.getStringPM10());
-
-    Serial.print(" CO2: " + sensors.getStringCO2());
+    Serial.print("-->[MAIN] CO2: " + sensors.getStringCO2());
     Serial.print(" CO2humi: " + String(sensors.getCO2humi()));
     Serial.print(" CO2temp: " + String(sensors.getCO2temp()));
 
@@ -49,17 +45,14 @@ void setup() {
     sensors.setSampleTime(5);                        // config sensors sample time interval
     sensors.setOnDataCallBack(&onSensorDataOk);      // all data read callback
     sensors.setOnErrorCallBack(&onSensorDataError);  // [optional] error callback
-    sensors.setDebugMode(true);                      // [optional] debug mode
+    sensors.setDebugMode(false);                     // [optional] debug mode
+    sensors.detectI2COnly(true);                     // force to only i2c sensors
 
-    // sensors.init();                                    // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
-    // sensors.init(sensors.Auto);                        // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
-    // sensors.init(sensors.Panasonic);                   // Force detection to Panasonic sensor
-    // sensors.init(sensors.Sensirion);                   // Force detection to Sensirion sensor
-    // sensors.init(sensors.Mhz19);                       // Force detection to Mhz14 or Mhz19 CO2 sensor
-    // sensors.init(sensors.CM1006);                      // Force detection to CM1106 CO2 sensor
-    // sensors.init(sensors.Auto,mRX,mTX);                // Auto detection and custom RX, TX pines
-    // sensors.init(sensors.Auto,PMS_RX,PMS_TX); // Auto detection, custom RX,TX and custom DHT config
-    sensors.init(sensors.Auto);
+    // sensors.setCO2RecalibrationFactor(400);       // calibration method (in outdoors)
+
+    sensors.scd30.setTemperatureOffset(2.0);         // example to set temp offset
+
+    sensors.init();
 
     if (sensors.isPmSensorConfigured())
         Serial.println("-->[SETUP] Sensor configured: " + sensors.getPmDeviceSelected());

--- a/examples/platformio/src/main.cpp
+++ b/examples/platformio/src/main.cpp
@@ -51,17 +51,19 @@ void setup() {
     sensors.setOnDataCallBack(&onSensorDataOk);     // all data read callback
     sensors.setOnErrorCallBack(&onSensorDataError); // [optional] error callback
     sensors.setDebugMode(true);                     // [optional] debug mode
+    sensors.detectI2COnly(false);                   // disable force to only i2c sensors
 
-    // sensors.init();                                    // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
-    // sensors.init(sensors.Auto);                        // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
-    // sensors.init(sensors.Panasonic);                   // Force detection to Panasonic sensor
-    // sensors.init(sensors.Sensirion);                   // Force detection to Sensirion sensor
-    // sensors.init(sensors.SDS011);                      // Force detection to Nova sensor
-    // sensors.init(sensors.Mhz19);                       // Force detection to Mhz14 or Mhz19 CO2 sensor 
-    // sensors.init(sensors.CM1006);                      // Force detection to CM1106 CO2 sensor
-    // sensors.init(sensors.Auto,mRX,mTX);                // Auto detection and custom RX, TX pines
-    // sensors.init(sensors.Auto,PMS_RX,PMS_TX); // Auto detection, custom RX,TX and custom DHT config
-    sensors.init(sensors.Auto); 
+    // sensors.init();                              // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
+    // sensors.init(sensors.Auto);                  // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
+    // sensors.init(sensors.Panasonic);             // Force detection to Panasonic sensor
+    // sensors.init(sensors.Sensirion);             // Force detection to Sensirion sensor
+    // sensors.init(sensors.Mhz19);                 // Force detection to Mhz14 or Mhz19 CO2 sensor
+    // sensors.init(sensors.SDS011);                // Force detection to SDS011 sensor
+    // sensors.init(sensors.CM1006);                // Force detection to CM1106 CO2 sensor
+    // sensors.init(sensors.Auto,mRX,mTX);          // Auto detection and custom RX, TX pines
+    // sensors.init(sensors.Auto,PMS_RX,PMS_TX);    // Auto detection, custom RX,TX and custom DHT config
+
+    sensors.init(); 
 
     if(sensors.isPmSensorConfigured())
         Serial.println("-->[SETUP] Sensor configured: " + sensors.getPmDeviceSelected());

--- a/examples/pm_sds011/pm_sds011.ino
+++ b/examples/pm_sds011/pm_sds011.ino
@@ -51,16 +51,6 @@ void setup() {
     sensors.setOnErrorCallBack(&onSensorDataError);  // [optional] error callback
     sensors.setDebugMode(true);                      // [optional] debug mode
 
-    // sensors.init();                                    // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
-    // sensors.init(sensors.Auto);                        // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
-    // sensors.init(sensors.Panasonic);                   // Force detection to Panasonic sensor
-    // sensors.init(sensors.Sensirion);                   // Force detection to Sensirion sensor
-    // sensors.init(sensors.SDS011);                      // Force detection to Nova sensor
-    // sensors.init(sensors.Mhz19);                       // Force detection to Mhz14 or Mhz19 CO2 sensor
-    // sensors.init(sensors.CM1006);                      // Force detection to CM1106 CO2 sensor
-    // sensors.init(sensors.SCD30co2);                    // Force detection to SCD30 CO2 sensor
-    // sensors.init(sensors.Auto,mRX,mTX);                // Auto detection and custom RX, TX pines
-    // sensors.init(sensors.Auto,PMS_RX,PMS_TX); // Auto detection, custom RX,TX and custom DHT config
     sensors.init(sensors.SDS011);
 
     if (sensors.isPmSensorConfigured())

--- a/examples/sps30i2c/sps30i2c.cpp
+++ b/examples/sps30i2c/sps30i2c.cpp
@@ -61,7 +61,5 @@ void setup() {
 uint64_t counter = 0;
 
 void loop() {
-
     sensors.loop();  // read sensor data and showed it
-    
 }

--- a/library.json
+++ b/library.json
@@ -1,10 +1,11 @@
 {
   "name": "CanAirIO Air Quality Sensors Library",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "homepage":"https://canair.io",
   "keywords": 
   [ 
     "Air quality",
+    "CO2",
     "Honeywell",
     "Panasonic",
     "Sensirion",
@@ -24,7 +25,7 @@
     "PM1.0",
     "PM10"
   ],
-  "description":"Air quality sensors manager: Honeywell, Plantower, Panasonic, Sensirion, SDS011, SCD30, etc, also it handling other kind sensors like AM2320, bme280, aht10, sht31, DHT and CO2 sensors like MHZ19, CM1106 and others. Autodetection via UART and i2c. ESP32/8266/Avr compatible. Other than examples, you can review a full implementation on CanAirIO proyect.",
+  "description":"Air quality sensors manager: Honeywell, Plantower, Panasonic, Sensirion, SDS011, SCD30, etc, also it handling other kind sensors like AM2320, bme280, aht10, sht31, DHT and CO2 sensors like MHZ19, CM1106, SCD30 and others. Autodetection via UART and i2c. ESP32/8266/Avr compatible. Other than examples, you can review a full implementation on CanAirIO proyect.",
   "repository":
   {
     "type": "git",
@@ -76,6 +77,7 @@
     {"name":"MH-Z19", "owner":"wifwaf", "version":"1.5.3"},
     {"name":"SparkFun SCD30 Arduino Library","owner":"sparkfun","version":"1.0.10"},
     {"name":"CM1106_UART", "version":"https://github.com/hpsaturn/CM1106_UART.git"},
+    {"name":"SN-GCJA5", "version":"https://github.com/paulvha/SN-GCJA5.git"},
     {"name":"Adafruit BME680 Library","owner":"adafruit","version":"2.0.0"}
   ]
 }

--- a/library.properties
+++ b/library.properties
@@ -1,11 +1,11 @@
 name=CanAirIO Air Quality Sensors Library
-version=0.2.2
+version=0.2.3
 author=@hpsaturn, CanAirIO project <info@canair.io>
 maintainer=Antonio Vanegas <hpsaturn@gmail.com>
 url=https://github.com/kike-canaries/canairio_sensorlib
-sentence=Air quality particle meter sensors manager for multiple sensors.
-paragraph=Supported Honeywell, Plantower, Panasonic, Sensirion, etc. and also it handling other kind sensors like AM2320 sensor.
+sentence=Air quality particle meter and CO2 sensors manager for multiple models.
+paragraph=Air quality sensors manager: Honeywell, Plantower, Panasonic, Sensirion, SDS011, SCD30, etc, also it handling other kind sensors like AM2320, bme280, aht10, sht31, DHT and CO2 sensors like MHZ19, CM1106, SCD30 and others. Autodetection via UART and i2c. ESP32/8266/Avr compatible. Other than examples, you can review a full implementation on CanAirIO project.
 category=sensors
-depends=Adafruit AM2320 sensor library,Adafruit Unified Sensor,sps30,Adafruit BME280 Library,AHT10,Adafruit BusIO,Adafruit SHT31 Library,DHT_nonblocking,MH-Z19,SparkFun SCD30 Arduino Library,CM1106_UART,Adafruit BME680 Library
+depends=Adafruit AM2320 sensor library,Adafruit Unified Sensor,sps30,Adafruit BME280 Library,AHT10,Adafruit BusIO,Adafruit SHT31 Library,DHT_nonblocking,MH-Z19,SparkFun SCD30 Arduino Library,CM1106_UART,SN-GCJA5,Adafruit BME680 Library
 license=GPL-3.0-only
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,6 +28,7 @@ lib_deps =
     wifwaf/MH-Z19 @ ^1.5.3
     sparkfun/SparkFun SCD30 Arduino Library @ ^1.0.10
     https://github.com/hpsaturn/CM1106_UART.git
+    https://github.com/paulvha/SN-GCJA5.git
     ; https://github.com/jcomas/CM1106_UART
     ; hpsaturn/CanAirIO Air Quality Sensors Library
 

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -706,9 +706,7 @@ bool Sensors::sps30UARTInit() {
         return false;
     }
 
-    if (devmode) {
-        if (sps30tests()) return false;
-    }
+    if (!sps30tests()) return false;
 
     // start measurement
     if (sps30.start() == true) {
@@ -735,7 +733,7 @@ bool Sensors::sps30I2CInit() {
     Serial.println("-->[I2CS] detected SPS30 sensor :)");
 
     if (devmode) {
-        if (sps30tests()) return false;
+        if (!sps30tests()) return false;
     }
 
     // start measurement
@@ -843,7 +841,7 @@ void Sensors::bme680Init() {
     bme680.setPressureOversampling(BME680_OS_4X);
     bme680.setIIRFilterSize(BME680_FILTER_SIZE_3);
     bme680.setGasHeater(320, 150);  // 320*C for 150 ms
-    DEBUG("BME680 set sea level pressure ", String(SEALEVELPRESSURE_HPA).c_str());
+    DEBUG("-->[BME680] BME680 set sea level pressure ", String(SEALEVELPRESSURE_HPA).c_str());
 }
 
 void Sensors::aht10Init() {

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -705,18 +705,10 @@ bool Sensors::sps30UARTInit() {
         sps30Errorloop((char *)"-->[E][SPS30] could not initialize communication channel.", 0);
         return false;
     }
-    // check for SPS30 connection
-    if (!sps30.probe()) {
-        sps30Errorloop((char *)"-->[E][SPS30] could not probe with SPS30.", 0);
-        return false;
+
+    if (devmode) {
+        if (sps30tests()) return false;
     }
-    else {
-        DEBUG("-->[SPS30] Detected SPS30 via UART.");
-        sps30DeviceInfo();
-    }
-    // reset SPS30 connection
-    if (!sps30.reset())
-        sps30Errorloop((char *)"-->[E][SPS30] could not reset.", 0);
 
     // start measurement
     if (sps30.start() == true) {
@@ -740,21 +732,11 @@ bool Sensors::sps30I2CInit() {
         sps30Errorloop((char *)"-->[E][SPS30] Could not set I2C communication channel.", 0);
         return false;
     }
+    Serial.println("-->[I2CS] detected SPS30 sensor :)");
 
-    // check for SPS30 connection
-    if (!sps30.probe()) {
-        sps30Errorloop((char *)"-->[E][SPS30] Could not probe with SPS30.", 0);
-        return false;
+    if (devmode) {
+        if (sps30tests()) return false;
     }
-    else {
-        DEBUG("-->[SPS30] Detected SPS30 via I2C.");
-        sps30DeviceInfo();
-    }
-
-    // reset SPS30 connection
-    if (!sps30.reset()) 
-        sps30Errorloop((char *)"-->[E][SPS30] could not reset.", 0);
-
 
     // start measurement
     if (sps30.start()) {
@@ -769,6 +751,23 @@ bool Sensors::sps30I2CInit() {
         sps30Errorloop((char *)"-->[E][SPS30] Could NOT start measurement.", 0);
 
     return false;
+}
+
+bool Sensors::sps30tests() {
+    // check for SPS30 connection
+    if (!sps30.probe()) {
+        sps30Errorloop((char *)"-->[E][SPS30] Could not probe with SPS30.", 0);
+        return false;
+    } else {
+        DEBUG("-->[SPS30] Detected SPS30 via I2C.");
+        sps30DeviceInfo();
+    }
+    // reset SPS30 connection
+    if (!sps30.reset()) {
+        sps30Errorloop((char *)"-->[E][SPS30] could not reset.", 0);
+        return false;
+    }
+    return true;
 }
 
 /**
@@ -821,23 +820,24 @@ void Sensors::sps30DeviceInfo() {
 void Sensors::am2320Init() {
     DEBUG("-->[AM2320] starting AM2320 sensor..");
     am2320 = Adafruit_AM2320();
-    am2320.begin();  // temp/humidity sensor
+    if (am2320.begin()) Serial.println("-->[I2CS] detected AM2330 sensor :)");
 }
 
 void Sensors::sht31Init() {
     DEBUG("-->[SHT31] starting SHT31 sensor..");
     sht31 = Adafruit_SHT31();
-    sht31.begin(0x44);  // temp/humidity sensor
+    if (sht31.begin(0x44)) Serial.println("-->[I2CS] detected SHT31 sensor :)");
 }
 
 void Sensors::bme280Init() {
     DEBUG("-->[BME280] starting BME280 sensor..");
-    bme280.begin(0x76);  // temp/humidity sensor
+    if (bme280.begin(0x76)) Serial.println("-->[I2CS] detected BME280 sensor :)");
 }
 
 void Sensors::bme680Init() {
-    DEBUG("-->[BME280] starting BME680 sensor..");
+    DEBUG("-->[BME680] starting BME680 sensor..");
     if (!bme680.begin()) return;
+    Serial.println("-->[I2CS] detected BME680 sensor :)");
     bme680.setTemperatureOversampling(BME680_OS_8X);
     bme680.setHumidityOversampling(BME680_OS_2X);
     bme680.setPressureOversampling(BME680_OS_4X);
@@ -849,30 +849,27 @@ void Sensors::bme680Init() {
 void Sensors::aht10Init() {
     DEBUG("-->[AHT10] starting AHT10 sensor..");
     aht10 = AHT10(AHT10_ADDRESS_0X38);
-    aht10.begin();  // temp/humidity sensor
+    if (aht10.begin()) Serial.println("-->[I2CS] detected AHT10 sensor :)");
 }
 
 void Sensors::CO2scd30Init() {
     DEBUG("-->[SCD30] starting CO2 SCD30 sensor..");
-    scd30.begin();
+    if (!scd30.begin()) return;
+    Serial.println("-->[I2CS] detected SCD30 sensor :)");
     delay(10);
     CO2scd30Read();
-    if (CO2 > 0) {
-        DEBUG("-->[SCD30] detected!");      
-        device_selected = "SCD30";  // TODO: sync this constants with app
-        device_type = 6;
-    }
+    device_selected = "SCD30";  // TODO: sync this constants with app
+    device_type = 6;
 }
 
 void Sensors::PMGCJA5Init() {
     DEBUG("-->[GCJA5] starting PANASONIC GCJA5 sensor..");
-    if (pmGCJA5.begin()) {
-        DEBUG("-->[GCJA5] PANASONIC via I2C detected!");
-        device_selected = "PANASONIC";
-        device_type = Panasonic;
-        uint8_t status = pmGCJA5.getStatusFan();
-        DEBUG("-->[GCJA5] FAN status: ",String(status).c_str());
-    }
+    if (!pmGCJA5.begin()) return;
+    Serial.println("-->[I2CS] detected SN-GCJA5 sensor :)");
+    device_selected = "PANASONIC";
+    device_type = Panasonic;
+    uint8_t status = pmGCJA5.getStatusFan();
+    DEBUG("-->[GCJA5] FAN status: ", String(status).c_str());
 }
 
 void Sensors::dhtInit() {

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -27,6 +27,7 @@ void Sensors::loop() {
         sht31Read();
         CO2scd30Read();
         PMGCJA5Read();
+        if(_only_i2c_sensors && device_type == Sensirion) sps30Read();
 
         if(!dataReady)DEBUG("-->[SENSORS] Any data from sensors? check your wirings!");
 
@@ -757,7 +758,6 @@ bool Sensors::sps30I2CInit() {
 
     // start measurement
     if (sps30.start()) {
-        sps30Read();
         DEBUG("-->[SPS30] Measurement OK");
         device_selected = "SENSIRION";
         device_type = Sensirion;

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -730,15 +730,13 @@ bool Sensors::sps30I2CInit() {
         sps30Errorloop((char *)"-->[E][SPS30] Could not set I2C communication channel.", 0);
         return false;
     }
-    Serial.println("-->[I2CS] detected SPS30 sensor :)");
 
-    if (devmode) {
-        if (!sps30tests()) return false;
-    }
+    if (!sps30tests()) return false;
 
     // start measurement
     if (sps30.start()) {
         DEBUG("-->[SPS30] Measurement OK");
+        Serial.println("-->[I2CS] detected SPS30 sensor :)");
         device_selected = "SENSIRION";
         device_type = Sensirion;
         if (sps30.I2C_expect() == 4)

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -18,9 +18,9 @@ using namespace std;
 #include <vector>
 
 /******************************************************************************
-* S E T U P  B O A R D   A N D  F I E L D S
+* S E T U P  ESP32 B O A R D S  A N D  F I E L D S
 * -------------------------------------------
-* if you need, please select board on platformio.ini file
+* Please select the board on platformio.ini file or pass it via build flag
 ******************************************************************************/
 #ifdef WEMOSOLED
 #define PMS_RX 13           // config for Wemos board & TTGO18650
@@ -42,7 +42,7 @@ using namespace std;
 #define PMS_RX 13  
 #define PMS_TX 12
 #define DHT_SENSOR_PIN 17
-#else
+#else                       // ** DEFAULT **
 #define PMS_RX 17           // config for D1MIN1 / TTGO T7 / Default for main ESP32 dev boards
 #define PMS_TX 16
 #define DHT_SENSOR_PIN 23      

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -9,6 +9,7 @@
 #include <Adafruit_Sensor.h>
 #include <MHZ19.h>
 #include <SparkFun_SCD30_Arduino_Library.h>
+#include <SparkFun_Particle_Sensor_SN-GCJA5_Arduino_Library.h>
 #include <dht_nonblocking.h>
 #include <sps30.h>
 #include <cm1106_uart.h>
@@ -106,6 +107,8 @@ class Sensors {
     CM1106_UART *sensor_CM1106;
     CM1106_sensor sensor;
     CM1106_ABC abc;
+    // Panasonic SN-GCJA5
+    SFE_PARTICLE_SENSOR pmGCJA5;
 
     void init(int pms_type = 0, int pms_rx = PMS_RX, int pms_tx = PMS_TX);
     void loop();
@@ -199,6 +202,9 @@ class Sensors {
 
     void CO2scd30Init();
     void CO2scd30Read();
+
+    void PMGCJA5Init();
+    void PMGCJA5Read();
 
     void dhtInit();
     void dhtRead();

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -228,6 +228,7 @@ class Sensors {
     bool sps30I2CInit();
     bool sps30UARTInit();
     bool sps30Read();
+    bool sps30tests();
     void sps30ErrToMess(char *mess, uint8_t r);
     void sps30Errorloop(char *mess, uint8_t r);
     void sps30DeviceInfo();


### PR DESCRIPTION
- [x] added support for Panasonic SN-GCJA5 sensor via i2c
- [x] improved SPS30 starting speed and I2C detection messages
- [x] fixed issue with sps30i2c read when forced only to i2c
- [x] approved by CanAirIO community with test on real hardware
- [x] updated documentation and samples
- [x] revision number  