### PR TITLE
implementation of SenseAir S8 CO2 sensor

### DIFF
--- a/library.json
+++ b/library.json
@@ -79,6 +79,7 @@
     {"name":"SparkFun SCD30 Arduino Library","owner":"sparkfun","version":"1.0.10"},
     {"name":"CM1106_UART", "version":"https://github.com/hpsaturn/CM1106_UART.git"},
     {"name":"SN-GCJA5", "version":"https://github.com/paulvha/SN-GCJA5.git"},
+    {"name":"SenseAirS8", "version":"https://github.com/hpsaturn/senseair_s8.git"},
     {"name":"Adafruit BME680 Library","owner":"adafruit","version":"2.0.0"}
   ]
 }

--- a/library.json
+++ b/library.json
@@ -79,7 +79,7 @@
     {"name":"SparkFun SCD30 Arduino Library","owner":"sparkfun","version":"1.0.10"},
     {"name":"CM1106_UART", "version":"https://github.com/hpsaturn/CM1106_UART.git"},
     {"name":"SN-GCJA5", "version":"https://github.com/paulvha/SN-GCJA5.git"},
-    {"name":"SenseAirS8", "version":"https://github.com/hpsaturn/senseair_s8.git"},
+    {"name":"senseair_s8", "version":"https://github.com/hpsaturn/senseair_s8.git"},
     {"name":"Adafruit BME680 Library","owner":"adafruit","version":"2.0.0"}
   ]
 }

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "CanAirIO Air Quality Sensors Library",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "homepage":"https://canair.io",
   "keywords": 
   [ 
@@ -18,6 +18,7 @@
     "AM2320",
     "mhz19",
     "scd30",
+    "SenseAir S8",
     "cm1106",
     "sds011",
     "particulate matter",
@@ -25,7 +26,7 @@
     "PM1.0",
     "PM10"
   ],
-  "description":"Air quality sensors manager: Honeywell, Plantower, Panasonic, Sensirion, SDS011, SCD30, etc, also it handling other kind sensors like AM2320, bme280, aht10, sht31, DHT and CO2 sensors like MHZ19, CM1106, SCD30 and others. Autodetection via UART and i2c. ESP32/8266/Avr compatible. Other than examples, you can review a full implementation on CanAirIO proyect.",
+  "description":"Generic sensor manager, abstratctions and bindings of multiple air sensors libraries: Honeywell, Plantower, Panasonic, Sensirion, Nova, etc. and CO2 sensors. Also it handling others environment sensors. This library is for general purpose but also is the sensors library base of CanAirIO project.",
   "repository":
   {
     "type": "git",

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
 name=CanAirIO Air Quality Sensors Library
-version=0.2.7
+version=0.2.8
 author=@hpsaturn, CanAirIO project <info@canair.io>
 maintainer=Antonio Vanegas <hpsaturn@gmail.com>
 url=https://github.com/kike-canaries/canairio_sensorlib
 sentence=Air quality particle meter and CO2 sensors manager for multiple models.
-paragraph=Air quality sensors manager: Honeywell, Plantower, Panasonic, Sensirion, SDS011, SCD30, etc, also it handling other kind sensors like AM2320, bme280, aht10, sht31, DHT and CO2 sensors like MHZ19, CM1106, SCD30 and others. Autodetection via UART and i2c. ESP32/8266/Avr compatible. Other than examples, you can review a full implementation on CanAirIO project.
+paragraph=Generic sensor manager, abstratctions and bindings of multiple air sensors libraries: Honeywell, Plantower, Panasonic, Sensirion, Nova, etc. and CO2 sensors. Also it handling others environment sensors. This library is for general purpose but also is the sensors library base of CanAirIO project.
 category=sensors
 depends=Adafruit AM2320 sensor library,Adafruit Unified Sensor,sps30,Adafruit BME280 Library,AHT10,Adafruit BusIO,Adafruit SHT31 Library,DHT_nonblocking,MH-Z19,SparkFun SCD30 Arduino Library,CM1106_UART,SN-GCJA5,Adafruit BME680 Library
 license=GPL-3.0-only

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,6 +29,7 @@ lib_deps =
     sparkfun/SparkFun SCD30 Arduino Library @ ^1.0.10
     https://github.com/hpsaturn/CM1106_UART.git
     https://github.com/paulvha/SN-GCJA5.git
+    https://github.com/hpsaturn/senseair_s8.git
     ; https://github.com/jcomas/CM1106_UART
     ; hpsaturn/CanAirIO Air Quality Sensors Library
 

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -100,7 +100,7 @@ void Sensors::setCO2RecalibrationFactor(int ppmValue) {
     }
     if (getPmDeviceSelected().equals("CM1106")) {
         Serial.println("-->[SENSORS] CM1106 setting calibration factor: " + String(ppmValue));
-        sensor_CM1106->start_calibration(ppmValue);
+        cm1106->start_calibration(ppmValue);
     }
     if (getPmDeviceSelected().equals("MHZ19")) {
         Serial.println("-->[SENSORS] MH-Z19 setting calibration factor: " + String(ppmValue));
@@ -383,7 +383,7 @@ bool Sensors::CO2Mhz19Read() {
 }
 
 bool Sensors::CO2CM1106Read() {
-    CO2 = sensor_CM1106->get_co2();;
+    CO2 = cm1106->get_co2();;
     if (CO2 > 0) {
         dataReady = true;
         DEBUG("-->[CM1106] read > done!");
@@ -698,10 +698,10 @@ bool Sensors::CO2Mhz19Init() {
 
 bool Sensors::CO2CM1106Init() {
     DEBUG("-->[CM1106] starting CM1106 sensor..");
-    sensor_CM1106 = new CM1106_UART(*_serial);
+    cm1106 = new CM1106_UART(*_serial);
 
     // Check if CM1106 is available
-    sensor_CM1106->get_software_version(cm1106sensor.softver);
+    cm1106->get_software_version(cm1106sensor.softver);
     int len = strlen(cm1106sensor.softver);
     if (len > 0) {
         if (len >= 10 && !strncmp(cm1106sensor.softver+len-5, "SL-NS", 5)) {
@@ -718,19 +718,19 @@ bool Sensors::CO2CM1106Init() {
 
     // Show sensor info
     DEBUG("-->[CM1106] Cubic CM1106 NDIR CO2 sensor");  
-    sensor_CM1106->get_serial_number(cm1106sensor.sn);
+    cm1106->get_serial_number(cm1106sensor.sn);
     DEBUG("-->[CM1106] Serial number:", cm1106sensor.sn);
     DEBUG("-->[CM1106] Software version:", cm1106sensor.softver);
 
     // Setup ABC parameters
     DEBUG("-->[CM1106] Setting ABC parameters...");
-    sensor_CM1106->set_ABC(CM1106_ABC_OPEN, 7, 415);    // 7 days cycle, 415 ppm for base
+    cm1106->set_ABC(CM1106_ABC_OPEN, 7, 415);    // 7 days cycle, 415 ppm for base
 
     // Force mode continous B for CM1106SL-NS
-    sensor_CM1106->set_working_status(1);
+    cm1106->set_working_status(1);
 
     // Getting ABC parameters
-    if (sensor_CM1106->get_ABC(&abc)) {
+    if (cm1106->get_ABC(&abc)) {
         DEBUG("-->[CM1106] ABC parameters:");
         if (abc.open_close == CM1106_ABC_OPEN) {
             DEBUG("-->[CM1106] Auto calibration is enabled");

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -106,6 +106,9 @@ void Sensors::setCO2RecalibrationFactor(int ppmValue) {
         Serial.println("-->[SENSORS] MH-Z19 setting calibration factor: " + String(ppmValue));
         mhz19.calibrate();
     }
+    if (getPmDeviceSelected().equals("SENSEAIRS8")) {
+        Serial.println("-->[SENSORS] SenseAir S8  setting calibration factor: " + String(ppmValue));
+    }
 }
 
 /// set SCD30 temperature compensation
@@ -389,6 +392,16 @@ bool Sensors::CO2CM1106Read() {
     return false;
 }
 
+bool Sensors::senseAirS8Read() {
+    CO2 = sensor_S8->get_co2();      // Request CO2 (as ppm)
+    if (CO2 > 0) {
+        dataReady = true;
+        DEBUG("-->[SENSEAIRS8] read > done!");
+        return true;
+    }
+    return false;
+}
+
 /**
  * @brief read sensor data. Sensor selected.
  * @return true if data is loaded from sensor
@@ -417,6 +430,10 @@ bool Sensors::pmSensorRead() {
 
         case CM1106:
             return CO2CM1106Read();
+            break;
+
+        case SENSEAIRS8:
+            return senseAirS8Read();
             break;
 
         default:
@@ -650,7 +667,7 @@ bool Sensors::pmSensorAutoDetect(int pms_type) {
     if (pms_type == SENSEAIRS8) {
         if (senseAirS8Init()) {
             device_selected = "SENSEAIRS8";
-            device_type = CM1106;
+            device_type = SENSEAIRS8;
             return true;
         }
     }
@@ -743,7 +760,7 @@ bool Sensors::senseAirS8Init() {
     }
     // Show S8 sensor info
 
-    Serial.println("-->[SENSEAIRS*] detected SenseAir S8 sensor :)");
+    Serial.println("-->[SENSEAIRS8] detected SenseAir S8 sensor :)");
     if (devmode) {
         Serial.printf("-->[SENSEAIRS8] Software version: %s\n", s8sensor.firmver);
         Serial.printf("-->[SENSEAIRS8] Sensor type: 0x%08x\n", sensor_S8->get_sensor_type_ID());

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -393,7 +393,7 @@ bool Sensors::CO2CM1106Read() {
 }
 
 bool Sensors::senseAirS8Read() {
-    CO2 = sensor_S8->get_co2();      // Request CO2 (as ppm)
+    CO2 = s8->get_co2();      // Request CO2 (as ppm)
     if (CO2 > 0) {
         dataReady = true;
         DEBUG("-->[SENSEAIRS8] read > done!");
@@ -746,9 +746,9 @@ bool Sensors::CO2CM1106Init() {
 
 bool Sensors::senseAirS8Init() {
     DEBUG("-->[SENSEAIRS8] starting S8 (UART) sensor..");
-    sensor_S8 = new S8(*_serial);
+    s8 = new S8(*_serial);
     // Check if S8 is available
-    sensor_S8->get_firmware_version(s8sensor.firmver);
+    s8->get_firmware_version(s8sensor.firmver);
     int len = strlen(s8sensor.firmver);
     if (len == 0) {
         DEBUG("-->[E][SENSEAIRS8] not detected!");
@@ -759,25 +759,25 @@ bool Sensors::senseAirS8Init() {
     Serial.println("-->[SENSEAIRS8] detected SenseAir S8 sensor :)");
     if (devmode) {
         Serial.printf("-->[SENSEAIRS8] Software version: %s\n", s8sensor.firmver);
-        Serial.printf("-->[SENSEAIRS8] Sensor type: 0x%08x\n", sensor_S8->get_sensor_type_ID());
-        Serial.printf("-->[SENSEAIRS8] Sensor ID:  %08x\n", sensor_S8->get_sensor_ID());
-        Serial.printf("-->[SENSEAIRS8] Memory map version: 0x%04x\n", sensor_S8->get_memory_map_version());
-        Serial.printf("-->[SENSEAIRS8] ABC period (0 = disabled): %d hours\n", sensor_S8->get_ABC_period());
+        Serial.printf("-->[SENSEAIRS8] Sensor type: 0x%08x\n", s8->get_sensor_type_ID());
+        Serial.printf("-->[SENSEAIRS8] Sensor ID:  %08x\n", s8->get_sensor_ID());
+        Serial.printf("-->[SENSEAIRS8] Memory map version: 0x%04x\n", s8->get_memory_map_version());
+        Serial.printf("-->[SENSEAIRS8] ABC period (0 = disabled): %d hours\n", s8->get_ABC_period());
     }
     DEBUG("-->[SENSEAIRS8] Disable ABC period");
-    sensor_S8->set_ABC_period(0);
+    s8->set_ABC_period(0);
     delay(1000);
-    if (devmode) Serial.printf("-->[SENSEAIRS8] ABC period (0 = disabled): %d hours\n", sensor_S8->get_ABC_period());
+    if (devmode) Serial.printf("-->[SENSEAIRS8] ABC period (0 = disabled): %d hours\n", s8->get_ABC_period());
 
     DEBUG("-->[SENSEAIRS8] ABC period set to 180 hours");
-    sensor_S8->set_ABC_period(180);
+    s8->set_ABC_period(180);
     delay(1000);
-    if (devmode) Serial.printf("ABC period (0 = disabled): %d hours\n", sensor_S8->get_ABC_period());
+    if (devmode) Serial.printf("ABC period (0 = disabled): %d hours\n", s8->get_ABC_period());
 
-    sensor_S8->get_meter_status();
-    sensor_S8->get_alarm_status();
-    sensor_S8->get_output_status();
-    sensor_S8->get_acknowledgement();
+    s8->get_meter_status();
+    s8->get_alarm_status();
+    s8->get_output_status();
+    s8->get_acknowledgement();
 
     return true;
 }

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -717,7 +717,7 @@ bool Sensors::CO2CM1106Init() {
     }     
 
     // Show sensor info
-    DEBUG("-->[CM1106] Cubic CM1106 NDIR CO2 sensor <<<");  
+    DEBUG("-->[CM1106] Cubic CM1106 NDIR CO2 sensor");  
     sensor_CM1106->get_serial_number(cm1106sensor.sn);
     DEBUG("-->[CM1106] Serial number:", cm1106sensor.sn);
     DEBUG("-->[CM1106] Software version:", cm1106sensor.softver);
@@ -729,21 +729,17 @@ bool Sensors::CO2CM1106Init() {
     // Force mode continous B for CM1106SL-NS
     sensor_CM1106->set_working_status(1);
 
-    // // Getting ABC parameters
-    // if (sensor_CM1106->get_ABC(&abc)) {
-    //     DEBUG("-->[CM1106] ABC parameters:");
-    //     if (abc.open_close == CM1106_ABC_OPEN) {
-    //         DEBUG("-->[CM1106] Auto calibration is enabled");
-    //     } else if (abc.open_close == CM1106_ABC_CLOSE) {
-    //         DEBUG("-->[CM1106] Auto calibration is disabled");
-    //     }
-    //     DEBUG("-->[CM1106] Calibration cycle: ", String(abc.cycle).c_str());
-    //     DEBUG("-->[CM1106] Calibration baseline: ", String(abc.base).c_str());
-    // }
-
-    // // Start calibration
-    // DEBUG("Starting calibration...");
-    // sensor_CM1106->start_calibration(400);
+    // Getting ABC parameters
+    if (sensor_CM1106->get_ABC(&abc)) {
+        DEBUG("-->[CM1106] ABC parameters:");
+        if (abc.open_close == CM1106_ABC_OPEN) {
+            DEBUG("-->[CM1106] Auto calibration is enabled");
+        } else if (abc.open_close == CM1106_ABC_CLOSE) {
+            DEBUG("-->[CM1106] Auto calibration is disabled");
+        }
+        DEBUG("-->[CM1106] Calibration cycle: ", String(abc.cycle).c_str());
+        DEBUG("-->[CM1106] Calibration baseline: ", String(abc.base).c_str());
+    }
 
     return true;
 }

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -96,7 +96,15 @@ void Sensors::setSampleTime(int seconds) {
 void Sensors::setCO2RecalibrationFactor(int ppmValue) {
     if (getPmDeviceSelected().equals("SCD30")) {
         Serial.println("-->[SENSORS] SCD30 setting calibration factor: " + String(ppmValue));
-        scd30.setForcedRecalibrationFactor(400);
+        scd30.setForcedRecalibrationFactor(ppmValue);
+    }
+    if (getPmDeviceSelected().equals("CM1106")) {
+        Serial.println("-->[SENSORS] CM1106 setting calibration factor: " + String(ppmValue));
+        sensor_CM1106->start_calibration(ppmValue);
+    }
+    if (getPmDeviceSelected().equals("MHZ19")) {
+        Serial.println("-->[SENSORS] MH-Z19 setting calibration factor: " + String(ppmValue));
+        mhz19.calibrate();
     }
 }
 
@@ -666,8 +674,8 @@ bool Sensors::pmSensorAutoDetect(int pms_type) {
 
 bool Sensors::CO2Mhz19Init() {
     DEBUG("-->[MH-Z19] starting MH-Z14 or MH-Z19 sensor..");
-    mhz19.begin(*_serial);    // *Serial(Stream) refence must be passed to library begin().
-    mhz19.autoCalibration(false);  // Turn auto calibration ON (OFF autoCalibration(false))
+    mhz19.begin(*_serial);
+    mhz19.autoCalibration(false); 
     return true;
 }
 

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -190,7 +190,7 @@ class Sensors {
     float pres = 0.0;   // Pressure
     float alt = 0.0;
     float gas = 0.0;
-
+    
     uint16_t CO2;         // CO2 in ppm
     float CO2humi = 0.0;  // temperature of the CO2 sensor
     float CO2temp = 0.0;  // temperature of the CO2 sensor
@@ -237,6 +237,7 @@ class Sensors {
     bool CO2Mhz19Init();
     bool CO2CM1106Init();
     bool senseAirS8Init();
+    bool senseAirS8Read();
 
     bool sps30I2CInit();
     bool sps30UARTInit();

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -13,6 +13,7 @@
 #include <dht_nonblocking.h>
 #include <sps30.h>
 #include <cm1106_uart.h>
+#include <s8.h>
 
 using namespace std;
 #include <vector>
@@ -67,7 +68,7 @@ typedef void (*voidCbFn)();
 class Sensors {
    public:
     /// Supported devices. Auto is for Honeywell and Plantower sensors and similars
-    enum SENSOR_TYPE { Auto, Panasonic, Sensirion, SDS011, Mhz19, CM1106 };
+    enum SENSOR_TYPE { Auto, Panasonic, Sensirion, SDS011, Mhz19, CM1106, SENSEAIRS8 };
     
     /// SPS30 values. Only for Sensirion SPS30 sensor.
     struct sps_values val;
@@ -111,10 +112,13 @@ class Sensors {
     SCD30 scd30;
     // CM1106 UART
     CM1106_UART *sensor_CM1106;
-    CM1106_sensor sensor;
+    CM1106_sensor cm1106sensor;
     CM1106_ABC abc;
     // Panasonic SN-GCJA5
     SFE_PARTICLE_SENSOR pmGCJA5;
+    // SenseAir S8 CO2 sensor
+    S8 *sensor_S8;
+    S8_sensor s8sensor;
 
     void init(int pms_type = 0, int pms_rx = PMS_RX, int pms_tx = PMS_TX);
     void loop();
@@ -232,6 +236,7 @@ class Sensors {
     int CO2CM1106val();
     bool CO2Mhz19Init();
     bool CO2CM1106Init();
+    bool senseAirS8Init();
 
     bool sps30I2CInit();
     bool sps30UARTInit();

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -117,7 +117,7 @@ class Sensors {
     // Panasonic SN-GCJA5
     SFE_PARTICLE_SENSOR pmGCJA5;
     // SenseAir S8 CO2 sensor
-    S8 *sensor_S8;
+    S8 *s8;
     S8_sensor s8sensor;
 
     void init(int pms_type = 0, int pms_rx = PMS_RX, int pms_tx = PMS_TX);

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -111,7 +111,7 @@ class Sensors {
     // SCD30 sensor
     SCD30 scd30;
     // CM1106 UART
-    CM1106_UART *sensor_CM1106;
+    CM1106_UART *cm1106;
     CM1106_sensor cm1106sensor;
     CM1106_ABC abc;
     // Panasonic SN-GCJA5


### PR DESCRIPTION
- [x] Added implementation of SenseAir that uses the @jcomas library (thanks)
- [x] Implemented Init methods
- [x] CM1106 refactor for possible conflicts with `sensor` object  
- [x] Calibration method for CM1106
- [x] Calibration method for MHZ19
- [x] Read methods for S8
- [x] Testing on real hardware S8
- [x] Provisional repo of s8 library [here](https://github.com/hpsaturn/senseair_s8.git)


## Pending tasks:

- [ ] Calibration method for S8
- [ ] Publish S8 library on @jcomas Github repo or PlatformIO registry (fix CI issues)