### PR TITLE
Test for Altitude problem with SCD30

### DIFF
--- a/examples/platformio/src/main.cpp
+++ b/examples/platformio/src/main.cpp
@@ -52,6 +52,8 @@ void setup() {
     sensors.setOnErrorCallBack(&onSensorDataError); // [optional] error callback
     sensors.setDebugMode(true);                     // [optional] debug mode
     sensors.detectI2COnly(false);                   // disable force to only i2c sensors
+
+    sensors.setCO2AltitudeOffset(2600.0);
     
     // sensors.init();                              // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
     // sensors.init(sensors.Auto);                  // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -139,7 +139,8 @@ void Sensors::setCO2RecalibrationFactor(int ppmValue)
 }
 
 void Sensors::setCO2AltitudeOffset(float altitude){
-    if (getPmDeviceSelected().equals("SCD30")) {
+    if (true) {
+
         this->altoffset = altitude;
         this->hpa = hpaCalculation(altitude);       //hPa hectopascal calculation based on altitude
         setSCD30AltitudeOffset(altoffset);


### PR DESCRIPTION
Added:
sensors.setCO2AltitudeOffset(2600.0);
for test the change in the altitude

and replecement:
if (getPmDeviceSelected().equals("SCD30"))
by   if (true) {
because in this routine the firmway don´t detect the sensor.

The problem is that the firmware erase the value of altitude that have the SCD30
and the app have problems too with this value.

