### PR TITLE
Accounts for SCD4x conversion rounding errors in temperature offset

### DIFF
--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1054,7 +1054,7 @@ void Sensors::setSCD30AltitudeOffset(float offset) {
 }
 
 void Sensors::CO2scd4xInit() {
-    float tTemperatureOffset;
+    float tTemperatureOffset, offsetDifference;
     uint16_t tSensorAltitude;
     uint16_t error;
     char errorMessage[256];
@@ -1085,7 +1085,8 @@ void Sensors::CO2scd4xInit() {
         delay(1);
     }
 
-    if (tTemperatureOffset != toffset) {
+    offsetDifference = abs((toffset*100) - (tTemperatureOffset*100)); 
+    if(offsetDifference > 0.5) { // Accounts for SCD4x conversion rounding errors in temperature offset
         Serial.println("-->[SLIB] SCD4x setting new temp offset: " + String(toffset));
         setSCD4xTempOffset(toffset);
         delay(1);


### PR DESCRIPTION
As SensirionI2CScd4x::setTemperatureOffset does an imprecise conversion to float, accounts for some difference in results when comparing.

```
uint16_t SensirionI2CScd4x::setTemperatureOffset(float tOffset) {
    uint16_t tOffsetTicks =
        static_cast<uint16_t>(tOffset * 65536.0 / 175.0 + 0.5f);
    return setTemperatureOffsetTicks(tOffsetTicks);
}
```
