### PR TITLE
Devel 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ NOTE: Panasonic via UART in ESP8266 maybe needs select in detection
 | SHT31       | i2c |  Auto | STABLE |
 | AHT10       | i2c |  Auto | STABLE |
 | BME280      | i2c |  Auto | STABLE |
+| BMP280      | i2c |  Auto | TESTING |
 | BME680      | i2c |  Auto | STABLE |
 | DHTxx       | TwoWire |  Auto | DEPRECATED |
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "CanAirIO Air Quality Sensors Library",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "homepage":"https://canair.io",
   "keywords": 
   [ 
@@ -71,19 +71,21 @@
   "dependencies":
   [
     {"name":"Adafruit Unified Sensor", "owner":"adafruit", "version":"1.1.4"},
-    {"name":"AM232X", "owner":"robtillaart", "version":"0.3.2"},
-    {"name":"sps30", "owner":"paulvha","version":"1.4.11"},
-    {"name":"Adafruit BME280 Library", "owner":"adafruit","version":"2.1.4"},
-    {"name":"AHT10", "owner":"enjoyneering","version":"1.1.0"},
-    {"name":"Adafruit BusIO", "owner":"adafruit","version":"1.7.3"},
+    {"name":"Adafruit BME280 Library", "owner":"adafruit","version":"2.2.1"},
+    {"name":"Adafruit BMP280 Library", "owner":"adafruit","version":"2.4.3"},
+    {"name":"Adafruit BME680 Library","owner":"adafruit","version":"2.0.1"},
+    {"name":"Adafruit BusIO", "owner":"adafruit","version":"1.9.8"},
     {"name":"Adafruit SHT31 Library", "owner":"adafruit","version":"2.0.0"},
-    {"name":"DHT_nonblocking", "version":"https://github.com/hpsaturn/DHT_nonblocking/archive/master.zip"},
+    {"name":"AM232X", "owner":"robtillaart", "version":"0.3.3"},
+    {"name":"AHT10", "owner":"enjoyneering","version":"1.1.0"},
+    {"name":"sps30", "owner":"paulvha","version":"1.4.11"},
     {"name":"MH-Z19", "owner":"wifwaf", "version":"1.5.3"},
-    {"name":"SparkFun SCD30 Arduino Library","owner":"sparkfun","version":"1.0.10"},
-    {"name":"CM1106_UART", "version":"https://github.com/jcomas/CM1106_UART.git"},
+    {"name":"SparkFun SCD30 Arduino Library","owner":"sparkfun","version":"1.0.16"},
+    {"name":"Sensirion Core","owner":"sensirion","version":"0.5.3"},
+    {"name":"Sensirion I2C SCD4x","owner":"sensirion","version":"0.3.1"},
+    {"name":"DHT_nonblocking", "version":"https://github.com/hpsaturn/DHT_nonblocking/archive/master.zip"},
     {"name":"SN-GCJA5", "version":"https://github.com/paulvha/SN-GCJA5.git"},
     {"name":"S8_UART", "version":"https://github.com/jcomas/S8_UART.git"},
-    {"name":"Adafruit BME680 Library","owner":"adafruit","version":"2.0.0"},
-    {"name":"Sensirion I2C SCD4x","owner":"sensirion","version":"0.3.1"}
+    {"name":"CM1106_UART", "version":"https://github.com/jcomas/CM1106_UART.git"}
   ]
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CanAirIO Air Quality Sensors Library
-version=0.3.8
+version=0.3.9
 author=@hpsaturn, CanAirIO project <info@canair.io>
 maintainer=Antonio Vanegas <hpsaturn@gmail.com>
 url=https://github.com/kike-canaries/canairio_sensorlib

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,26 +13,26 @@ upload_speed = 1500000
 monitor_speed = 115200
 monitor_filters = time
 build_flags =
-    -D SRC_REV=337
+    -D SRC_REV=338
     -D CORE_DEBUG_LEVEL=0
 lib_deps =
-    adafruit/Adafruit Unified Sensor @ 1.1.4
-    adafruit/Adafruit BME280 Library @ 2.2.0
-    adafruit/Adafruit BME680 Library @ 2.0.1
-    adafruit/Adafruit BusIO @ 1.8.3
-    adafruit/Adafruit SHT31 Library @ 2.0.0
-    robtillaart/AM232X @ ^0.3.2
-    enjoyneering/AHT10 @ ^1.1.0
-    https://github.com/hpsaturn/DHT_nonblocking.git
-    paulvha/sps30 @ 1.4.11
-    wifwaf/MH-Z19 @ ^1.5.3
-    sparkfun/SparkFun SCD30 Arduino Library @ ^1.0.10
-    sensirion/Sensirion Core@^0.5.2
-    https://github.com/Sensirion/arduino-i2c-scd4x.git
-    https://github.com/paulvha/SN-GCJA5.git
-    https://github.com/jcomas/S8_UART.git
-    https://github.com/jcomas/CM1106_UART.git
-    ; hpsaturn/CanAirIO Air Quality Sensors Library
+  adafruit/Adafruit Unified Sensor @ 1.1.4
+	adafruit/Adafruit BME280 Library @ 2.2.1
+	adafruit/Adafruit BMP280 Library @ 2.4.3
+	adafruit/Adafruit BME680 Library @ 2.0.1
+	adafruit/Adafruit BusIO @ 1.9.8
+	adafruit/Adafruit SHT31 Library @ 2.0.0
+	robtillaart/AM232X @ 0.3.3
+	enjoyneering/AHT10 @ 1.1.0
+	paulvha/sps30 @ 1.4.11
+	wifwaf/MH-Z19 @ 1.5.3
+	sparkfun/SparkFun SCD30 Arduino Library @ 1.0.16
+  sensirion/Sensirion Core @ 0.5.3
+	sensirion/Sensirion I2C SCD4x @ 0.3.1
+	https://github.com/hpsaturn/DHT_nonblocking.git
+	https://github.com/paulvha/SN-GCJA5.git
+	https://github.com/jcomas/S8_UART.git
+	https://github.com/jcomas/CM1106_UART.git
 
 [esp32_common]
 platform = espressif32

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1080,7 +1080,7 @@ void Sensors::setSCD30AltitudeOffset(float offset) {
 }
 
 void Sensors::CO2scd4xInit() {
-    float tTemperatureOffset;
+    float tTemperatureOffset, offsetDifference;
     uint16_t tSensorAltitude;
     uint16_t error;
     char errorMessage[256];
@@ -1111,7 +1111,8 @@ void Sensors::CO2scd4xInit() {
         delay(1);
     }
 
-    if (tTemperatureOffset != toffset) {
+    offsetDifference = abs((toffset*100) - (tTemperatureOffset*100)); 
+    if(offsetDifference > 0.5) { // Accounts for SCD4x conversion rounding errors in temperature offset
         Serial.println("-->[SLIB] SCD4x setting new temp offset: " + String(toffset));
         setSCD4xTempOffset(toffset);
         delay(1);

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -245,6 +245,7 @@ float Sensors::getTemperature() {
 void Sensors::setTempOffset(float offset){
     toffset = offset;
     setSCD30TempOffset(toffset);
+    setSCD4xTempOffset(toffset);
 }
 
 float Sensors::getGas() {
@@ -1027,7 +1028,7 @@ void Sensors::CO2scd30Init() {
         delay(10);
     }
 
-    if(scd30.getTemperatureOffset() != toffset) {
+    if(uint16_t((scd30.getTemperatureOffset()*100)) != (uint16_t(toffset*100))) {
         Serial.println("-->[SLIB] SCD30 setting new temp offset: " + String(toffset));
         setSCD30TempOffset(toffset);
         delay(10);

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -23,6 +23,7 @@ void Sensors::loop() {
         dhtRead();
         am2320Read();
         bme280Read();
+        bmp280Read();
         bme680Read();
         aht10Read();
         sht31Read();
@@ -30,7 +31,7 @@ void Sensors::loop() {
         CO2scd4xRead();
         PMGCJA5Read();
 
-        if(i2conly && device_type == Sensirion) sps30Read();
+        if(i2conly && device_type == SSPS30) sps30Read();
 
         if(!dataReady)DEBUG("-->[SLIB] Any data from sensors? check your wirings!");
 
@@ -81,6 +82,7 @@ void Sensors::init(int pms_type, int pms_rx, int pms_tx) {
     am2320Init();
     sht31Init();
     bme280Init();
+    bmp280Init();
     bme680Init();
     aht10Init();
     dhtInit();
@@ -464,7 +466,7 @@ bool Sensors::pmSensorRead() {
             return pmPanasonicRead();
             break;
 
-        case Sensirion:
+        case SSPS30:
             return sps30Read();
             break;
 
@@ -510,12 +512,24 @@ void Sensors::am2320Read() {
 void Sensors::bme280Read() {
     float humi1 = bme280.readHumidity();
     float temp1 = bme280.readTemperature();
-    if (humi1 != 0) humi = humi1;
-    if (temp1 != 0) {
-        temp = temp1-toffset;
-        dataReady = true;
-        DEBUG("-->[SLIB] BME280 read > done!");
-    }
+    if (isnan(humi1) || humi1 == 0) return;
+    humi = humi1;
+    temp = temp1-toffset;
+    pres = bme280.readPressure();
+    alt = bme280.readAltitude(SEALEVELPRESSURE_HPA);
+    dataReady = true;
+    DEBUG("-->[SLIB] BME280 read > done!");
+}
+
+void Sensors::bmp280Read() {
+    float temp1 = bmp280.readTemperature();
+    float press1 = bmp280.readPressure();
+    if (press1 == 0) return;
+    temp = temp1-toffset;
+    pres = bmp280.readPressure();
+    alt = bmp280.readAltitude(SEALEVELPRESSURE_HPA);
+    dataReady = true;
+    DEBUG("-->[SLIB] BME280 read > done!");
 }
 
 void Sensors::bme680Read() {
@@ -666,7 +680,7 @@ bool Sensors::sensorSerialInit(int pms_type, int pms_rx, int pms_tx) {
     else if (pms_type == Panasonic) {
         DEBUG("-->[SLIB] UART detecting Panasonic PM sensor..");
         if (!serialInit(pms_type, 9600, pms_rx, pms_tx)) return false;
-    } else if (pms_type == Sensirion) {
+    } else if (pms_type == SSPS30) {
         DEBUG("-->[SLIB] UART detecting SPS30 PM sensor..");
         if (!serialInit(pms_type, 115200, pms_rx, pms_tx)) return false;
     } else if (pms_type == SDS011) {
@@ -704,10 +718,10 @@ bool Sensors::sensorSerialInit(int pms_type, int pms_rx, int pms_tx) {
 bool Sensors::pmSensorAutoDetect(int pms_type) {
     delay(1000);  // sync serial
 
-    if (pms_type == Sensirion) {
+    if (pms_type == SSPS30) {
         if (sps30UARTInit()) {
             device_selected = "SENSIRION";
-            device_type = Sensirion;
+            device_type = SSPS30;
             return true;
         }
     }
@@ -881,7 +895,7 @@ bool Sensors::sps30UARTInit() {
 }
 
 bool Sensors::sps30I2CInit() {
-    if (device_type == Sensirion) return false;
+    if (device_type == SSPS30) return false;
     
     DEBUG("-->[SLIB] I2C SPS30 starting sensor..");
 
@@ -902,7 +916,7 @@ bool Sensors::sps30I2CInit() {
         DEBUG("-->[SLIB] SPS30 Measurement OK");
         Serial.println("-->[SLIB] I2C detected SPS30 sensor :)");
         device_selected = "SENSIRION";
-        device_type = Sensirion;
+        device_type = SSPS30;
         if (sps30.I2C_expect() == 4)
             DEBUG("[E][SLIB] SPS30 due to I2C buffersize only PM values  \n");
         return true;
@@ -984,12 +998,24 @@ void Sensors::am2320Init() {
 void Sensors::sht31Init() {
     DEBUG("-->[SLIB] SHT31 starting SHT31 sensor..");
     sht31 = Adafruit_SHT31();
-    if (sht31.begin(0x44)) Serial.println("-->[SLIB] I2C detected SHT31 sensor :)");
+    if (sht31.begin()) Serial.println("-->[SLIB] I2C detected SHT31 sensor :)");
 }
 
 void Sensors::bme280Init() {
     DEBUG("-->[SLIB] BME280 starting BME280 sensor..");
-    if (bme280.begin(0x76)) Serial.println("-->[SLIB] I2C detected BME280 sensor :)");
+    if (bme280.begin()) Serial.println("-->[SLIB] I2C detected BME280 sensor :)");
+}
+
+void Sensors::bmp280Init() {
+    DEBUG("-->[SLIB] BMP280 starting BMP280 sensor..");
+    if (!bmp280.begin()) return;
+    Serial.println("-->[SLIB] I2C detected BMP280 sensor :)");
+    // Default settings from datasheet.
+    bmp280.setSampling(Adafruit_BMP280::MODE_NORMAL,  // Operating Mode.
+                    Adafruit_BMP280::SAMPLING_X2,     // Temp. oversampling
+                    Adafruit_BMP280::SAMPLING_X16,    // Pressure oversampling
+                    Adafruit_BMP280::FILTER_X16,      // Filtering.
+                    Adafruit_BMP280::STANDBY_MS_500); // Standby time.
 }
 
 void Sensors::bme680Init() {
@@ -1029,7 +1055,6 @@ void Sensors::CO2scd30Init() {
     }
 
     if(uint16_t((scd30.getTemperatureOffset()*100)) != (uint16_t(toffset*100))) {
-        Serial.println("-->[SLIB] SCD30 setting new temp offset: " + String(toffset));
         setSCD30TempOffset(toffset);
         delay(10);
     }
@@ -1222,7 +1247,7 @@ bool Sensors::serialInit(int pms_type, long speed_baud, int pms_rx, int pms_tx) 
             break;
 
         case SERIALPORT2:
-            if (pms_type == Sensirion)
+            if (pms_type == SSPS30)
                 Serial2.begin(speed_baud);
             else
                 Serial2.begin(speed_baud, SERIAL_8N1, pms_rx, pms_tx, false);
@@ -1246,7 +1271,7 @@ bool Sensors::serialInit(int pms_type, long speed_baud, int pms_rx, int pms_tx) 
 #if defined(INCLUDE_SOFTWARE_SERIAL)
                 DEBUG("-->[SLIB] swSerial init on pin: ", String(pms_rx).c_str());
                 static SoftwareSerial swSerial(pms_rx, pms_tx);
-                if (pms_type == Sensirion)
+                if (pms_type == SSPS30)
                     swSerial.begin(speed_baud);
                 else if (pms_type == Panasonic)
                     swSerial.begin(speed_baud, SWSERIAL_8E1, pms_rx, pms_tx, false);

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -4,6 +4,7 @@
 #include <AHT10.h>
 #include <AM232X.h>
 #include <Adafruit_BME280.h>
+#include <Adafruit_BMP280.h>
 #include <Adafruit_BME680.h>
 #include <Adafruit_SHT31.h>
 #include <Adafruit_Sensor.h>
@@ -69,7 +70,7 @@ typedef void (*voidCbFn)();
 class Sensors {
    public:
     /// Supported devices. Auto is for Honeywell and Plantower sensors and similars
-    enum SENSOR_TYPE { Auto, Panasonic, Sensirion, SDS011, Mhz19, CM1106, SENSEAIRS8, SSCD30, SSCD4x };
+    enum SENSOR_TYPE { Auto, Panasonic, SSPS30, SDS011, Mhz19, CM1106, SENSEAIRS8, SSCD30, SSCD4x };
     
     /// SPS30 values. Only for Sensirion SPS30 sensor.
     struct sps_values val;
@@ -103,6 +104,8 @@ class Sensors {
     AM232X am2320;
     // BME280 (Humidity, Pressure, Altitude and Temperature)
     Adafruit_BME280 bme280;
+    // BMP280 (Humidity, Pressure, Altitude and Temperature)
+    Adafruit_BMP280 bmp280;
     // BME680 (Humidity, Gas, IAQ, Pressure, Altitude and Temperature)
     Adafruit_BME680 bme680; 
     // AHT10
@@ -210,6 +213,9 @@ class Sensors {
 
     void bme280Init();
     void bme280Read();
+
+    void bmp280Init();
+    void bmp280Read();
 
     void bme680Init();
     void bme680Read();


### PR DESCRIPTION
ec02fe2 Accounts for SCD4x conversion rounding errors in temperature offset
e8a30bb Include SCD4x in setTempOffset
8420e8d Fix bug with float comparation https://t.me/canairio/18540
d467acb New BMP280 sensor and BME280 issues fixed
4d3c6c4 changed the defaults address for bme280 and sht31 sensors
a27e341 new implementation of BMP680 sensor
f016731 fixed all PlatformIO libraries to static version
cb5cb49 fixed issue with bme280 sensor detection 
2817cc1 possible fix to issue #101
8a4792d refactor enum variable Sensirion to SSPS30

Thanks to @melkati @roberbike  @danielbernalb @lemeit
 for report issues and fixes
