### PR TITLE
Don't multiply the measurement interval by 2 for SCD30

### DIFF
--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -95,8 +95,8 @@ void Sensors::setSampleTime(int seconds) {
     sample_time = seconds;
     Serial.println("-->[SLIB] new sample time: " + String(seconds));
     if(getMainDeviceSelected().equals("SCD30")){
-        scd30.setMeasurementInterval(seconds * 2);
-        Serial.println("-->[SLIB] SCD30 interval time to (2x): " + String(seconds * 2));
+        scd30.setMeasurementInterval(seconds);
+        Serial.println("-->[SLIB] SCD30 interval time to: " + String(seconds));
     }
 }
 


### PR DESCRIPTION
## Description

Note: This modification only affects Sensirion's SCD30 sensor.

When modifying measurement interval (by calling method void Sensors::setSampleTime(int seconds)), library multiplied time by 2 in an intent to reduce power consumption.
Now it 's  modified so what is does coincide with function name.
This optimization to reduce power consumption., if needed , should be done by function caller as, for example:

Change:

`sensors.setSampleTime(seconds)
`

To:

```
if(getMainDeviceSelected().equals("SCD30")){
        sensorssensors.setSampleTime(seconds * 2);
    }
```

## Related Issues

**Warning:** SCD30 sensors should be calibrated again after modifying measurement interval, so you should do it or modify the function caller at the same time you upgrade the library.

## Tests

- [x] Tested OK in CO2 Gadget