### PR TITLE
Geiger first test version

### DIFF
--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -72,7 +72,7 @@ bool Sensors::readAllSensors() {
     bme680Read();
     dhtRead();
     disableWire1();
-
+    geigerLoop();;
     printValues();
     printSensorsRegistered(devmode);
     printUnitsRegistered(devmode);
@@ -117,6 +117,7 @@ void Sensors::init(int pms_type, int pms_rx, int pms_tx) {
     sht31Init();
     aht10Init();
     dhtInit();
+    geigerInit();
     printSensorsRegistered(true);
 }
 
@@ -1717,3 +1718,103 @@ bool Sensors::serialInit(int pms_type, unsigned long speed_baud, int pms_rx, int
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SENSORSHANDLER)
 Sensors sensors;
 #endif
+
+// *************** GEIGER ****************
+// ***************************************
+
+
+ 
+// variables shared between main code and interrupt code
+hw_timer_t * timer = NULL;
+volatile uint32_t updateTime = 0;       // time for next update
+volatile uint16_t tic_cnt = 0;
+ 
+// To calculate a running average over 10 sec, we keep tic counts in 250ms intervals and add all 40 tic_buf values
+#define TICBUFSIZE 40                   // running average buffer size
+volatile uint16_t tic_buf[TICBUFSIZE];  // buffer for 40 times 250ms tick values (to have a running average for 10 seconds)
+volatile uint16_t tic_buf_cnt = 0;
+ 
+// In order to display a history of the last 7 minutes, we keep the last 50 values of 10sec tics
+#define SEC10BUFSIZE 50                 // history array for displaymode==true
+volatile uint16_t sec10 = 0;            // every 10 seconds counter
+volatile uint16_t sec10_buf[SEC10BUFSIZE];  // buffer to hold 10 sec history (40*10 = 400 seconds)
+volatile bool sec10updated = false;     // set to true when sec10_buf is updated
+ 
+ 
+// #########################################################################
+// Interrupt routine called on each click from the geiger tube
+//
+void IRAM_ATTR TicISR() {
+  tic_cnt++;
+}
+ 
+// #########################################################################
+// Interrupt timer routine called every 250 ms
+//
+void IRAM_ATTR onTimer() {
+  tic_buf[tic_buf_cnt++] = tic_cnt;
+  tic_cnt = 0;
+  if (tic_buf_cnt>=TICBUFSIZE) {
+    uint16_t tot = 0;
+    for (int i=0; i<TICBUFSIZE; i++) tot += tic_buf[i];
+    sec10_buf[sec10++] = tot;
+    tic_buf_cnt = 0;    
+    if (sec10>=SEC10BUFSIZE) sec10 = 0;
+    sec10updated = true;
+  }
+}
+ 
+ // Convert tics to mR/hr
+float tics2mrem(uint16_t tics) {
+  return float(tics) * TICFACTOR;
+}
+
+ void geigerInit() {
+  
+  Serial.begin(115200); // For debug
+  Serial.println("Geiger counter startup");
+  updateTime = millis(); // Next update time
+ // attach interrupt routine to TIC interface from the geiger counter module
+  pinMode(PINTIC, INPUT);
+  attachInterrupt(PINTIC, TicISR, FALLING);
+ 
+  // attach interrupt routine to internal timer, to fire every 250 ms
+  timer = timerBegin(0, 80, true);
+  timerAttachInterrupt(timer, &onTimer, true);
+  timerAlarmWrite(timer, 250000, true); // 250 ms
+  timerAlarmEnable(timer);
+  Serial.println("Geiger counter ready");
+}
+
+void geigerLoop() {
+  
+ // curent mR/hr value to display - add all tics from walking average 10 seconds
+  uint16_t v=0;
+  for (int i=0; i<TICBUFSIZE; i++) {
+     v+=tic_buf[i];
+  }
+     
+   // convert tics to mR/hr and put in display buffer for TFT
+  float mrem = tics2mrem(v); 
+  char buf[12];
+  dtostrf(mrem, 7, (mrem<1 ? 2: (mrem<10 ? 1 : 0)), buf); 
+
+  Serial.println("tics2mrem"); Serial.println (mrem);
+  Serial.println("tic2men"); Serial.println(v);
+
+}
+
+/*// Convert tics to mR/hr
+//
+float tics2mrem(uint16_t tics) {
+  return float(tics) * TICFACTOR;
+}
+*/ 
+
+/* // convert millirem value to a log percentage on analog and bar graph
+//
+int mrem2perc(float mrem, int maxperc) {
+  if (mrem<=0) {
+    return 0;
+  } */
+ 

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1799,8 +1799,8 @@ void geigerLoop() {
   char buf[12];
   dtostrf(mrem, 7, (mrem<1 ? 2: (mrem<10 ? 1 : 0)), buf); 
 
-  Serial.println("tics2mrem"); Serial.println (mrem);
-  Serial.println("tic2men"); Serial.println(v);
+  Serial.println("mili Rem"); Serial.println (mrem);
+  Serial.println("tics"); Serial.println(v);
 
 }
 

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -20,6 +20,12 @@
 #define CSL_VERSION "0.5.4"
 #define CSL_REVISION 357
 
+/**************************************************************
+ *                          GEIGER
+ * ************************************************************/
+#define PINTIC 27           // GPIO18 is tic from geiger counter
+#define TICFACTOR 0.05      // factor between number of tics/second --> mR/hr
+
 /***************************************************************
 * S E T U P   E S P 3 2   B O A R D S   A N D   F I E L D S
 ***************************************************************/
@@ -98,7 +104,8 @@
     X(PRESS, "hPa", "P")       \
     X(ALT, "m", "Alt")         \
     X(GAS, "Ohm", "Gas")       \
-    X(UCOUNT, "COUNT", "UCOUNT")
+    X(UCOUNT, "COUNT", "UCOUNT")\
+    X(RADIATION, "mR", "mRem")
 
 #define X(unit, symbol, name) unit,
 typedef enum UNIT : size_t { SENSOR_UNITS } UNIT;
@@ -121,7 +128,8 @@ typedef enum UNIT : size_t { SENSOR_UNITS } UNIT;
     X(SAHT10, "AHT10", 3)   \
     X(SAM232X, "AM232X", 3) \
     X(SDHTX, "DHTX", 3)     \
-    X(SCOUNT, "SCOUNT", 3)
+    X(SCOUNT, "SCOUNT", 3) /* \
+    X(RADIATION, "CAJOE", 2) */
 
 #define X(utype, uname, umaintype) utype,
 typedef enum SENSORS : size_t { SENSORS_TYPES } SENSORS;  // backward compatibility
@@ -455,3 +463,6 @@ extern Sensors sensors;
 #endif
 
 #endif
+
+void geigerInit();
+void geigerLoop();


### PR DESCRIPTION
First test version to add a cajone v1.1 radiation geiger sensor.
 Calculation of radiation dose: 1 Sievert (Sv) = 100 Rem = 100,000 mR ==> 1 μSv = 0.1 mR
 Doses is indicated in mR/hour.
 Background radiation is 365 mR/year => 0.042 mR/hour
 Max doses radiation workers 5000 mR/year => 0.57 mR/hour
we can use the number of tics/ 10 seconds to estimate the doses in mR/hour:
    tics_per_10sec * TICFACTOR.

13:30:17.400 > == Sensor test setup ==
13:30:17.400 >
13:30:17.400 > -->[SETUP] Detecting sensors..
13:30:17.400 > -->[SLIB] new sample time        : 5
13:30:17.405 > -->[SLIB] temperature offset     : 0.00
13:30:17.405 > -->[SLIB] altitude offset        : 0.00
13:30:17.411 > -->[SLIB] sea level pressure     : 1013.25 hPa
13:30:17.416 > -->[SLIB] only i2c sensors       : false
13:30:23.978 > Geiger counter startup
13:30:23.983 > Geiger counter ready
13:30:23.983 > -->[SLIB] Sensors devices count  : 0 ()
13:30:24.524 > mili Rem
13:30:24.526 > 0.00
13:30:24.526 > tics
13:30:24.526 > 0
13:30:29.525 > mili Rem
13:30:29.526 > 0.10
13:30:29.526 > tics
13:30:29.526 > 2
13:30:34.524 > mili Rem
13:30:34.527 > 0.15
13:30:34.527 > tics
13:30:34.527 > 3
13:30:39.528 > mili Rem
13:30:39.528 > 0.05
13:30:39.528 > tics
13:30:39.528 > 1