### PR TITLE
Fix issue 143 aht10

### DIFF
--- a/examples/advanced_sensirion/platformio.ini
+++ b/examples/advanced_sensirion/platformio.ini
@@ -33,15 +33,15 @@ lib_deps =
 	adafruit/Adafruit SCD30 @ 1.0.8
 	adafruit/Adafruit BusIO @ 1.11.6
 	robtillaart/AM232X @ 0.4.1
-	enjoyneering/AHT10 @ 1.1.0
 	paulvha/sps30 @ 1.4.12
 	wifwaf/MH-Z19 @ 1.5.3
+	jcomas/S8_UART @ 1.0.1
 	sensirion/Sensirion Core @ 0.5.3
 	sensirion/Sensirion I2C SCD4x @ 0.3.1
+	https://github.com/enjoyneering/AHTxx.git#eb21571
 	https://github.com/hpsaturn/DHT_nonblocking.git#ec6e5b9
-	https://github.com/paulvha/SN-GCJA5.git
-	https://github.com/jcomas/S8_UART.git
-	https://github.com/jcomas/CM1106_UART.git
+	https://github.com/paulvha/SN-GCJA5.git#f261968
+	https://github.com/jcomas/CM1106_UART.git#da0eb4e	
 
 [env:esp32dev]
 platform = espressif32

--- a/examples/wio_terminal/src/main.cpp
+++ b/examples/wio_terminal/src/main.cpp
@@ -1,7 +1,7 @@
 /**
  * @file main.cpp
  * @author Antonio Vanegas @hpsaturn
- * @date June 2018 - 2020
+ * @date June 2018 - 2022
  * @brief Particle meter sensor tests
  * @license GPL3
  * 
@@ -69,7 +69,7 @@ void setup() {
     sensors.setOnDataCallBack(&onSensorDataOk);     // all data read callback
     sensors.setOnErrorCallBack(&onSensorDataError); // [optional] error callback
     sensors.setDebugMode(true);                     // [optional] debug mode
-    sensors.detectI2COnly(true);                   // disable force to only i2c sensors
+    sensors.detectI2COnly(true);                    // disable force to only i2c sensors
     sensors.init();                                 // Auto detection to UART and i2c sensors
 }
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "CanAirIO Air Quality Sensors Library",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "homepage":"https://canair.io",
   "keywords": 
   [ 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "CanAirIO Air Quality Sensors Library",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "homepage":"https://canair.io",
   "keywords": 
   [ 
@@ -83,14 +83,15 @@
     {"name":"Adafruit SCD30", "owner":"adafruit","version":"1.0.8"},
     {"name":"Adafruit BusIO", "owner":"adafruit","version":"1.11.6"},
     {"name":"AM232X", "owner":"robtillaart", "version":"0.4.1"},
-    {"name":"AHT10", "owner":"enjoyneering","version":"1.1.0"},
     {"name":"sps30", "owner":"paulvha","version":"1.4.12"},
     {"name":"MH-Z19", "owner":"wifwaf", "version":"1.5.3"},
+    {"name":"S8_UART", "owner":"jcomas", "version":"1.0.1"},
     {"name":"Sensirion Core","owner":"sensirion","version":"0.5.3"},
     {"name":"Sensirion I2C SCD4x","owner":"sensirion","version":"0.3.1"},
+
     {"name":"DHT_nonblocking", "version":"https://github.com/hpsaturn/DHT_nonblocking.git#ec6e5b9"},
-    {"name":"SN-GCJA5", "version":"https://github.com/paulvha/SN-GCJA5.git"},
-    {"name":"S8_UART", "version":"https://github.com/jcomas/S8_UART.git"},
-    {"name":"CM1106_UART", "version":"https://github.com/jcomas/CM1106_UART.git"}
+    {"name":"AHTxx", "version":"https://github.com/enjoyneering/AHTxx.git#eb21571"},
+    {"name":"SN-GCJA5", "version":"https://github.com/paulvha/SN-GCJA5.git#f261968"},
+    {"name":"CM1106_UART", "version":"https://github.com/jcomas/CM1106_UART.git#da0eb4e"}
   ]
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CanAirIO Air Quality Sensors Library
-version=0.5.8
+version=0.5.9
 author=@hpsaturn, CanAirIO project <info@canair.io>
 maintainer=Antonio Vanegas <hpsaturn@gmail.com>
 url=https://github.com/kike-canaries/canairio_sensorlib

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CanAirIO Air Quality Sensors Library
-version=0.5.9
+version=0.6.0
 author=@hpsaturn, CanAirIO project <info@canair.io>
 maintainer=Antonio Vanegas <hpsaturn@gmail.com>
 url=https://github.com/kike-canaries/canairio_sensorlib

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ monitor_filters = time
 build_flags =
     -D CORE_DEBUG_LEVEL=0
 lib_deps =
+
 	adafruit/Adafruit Unified Sensor @ 1.1.5
 	adafruit/Adafruit BME280 Library @ 2.2.2
 	adafruit/Adafruit BMP280 Library @ 2.6.2
@@ -23,15 +24,15 @@ lib_deps =
 	adafruit/Adafruit SCD30 @ 1.0.8
 	adafruit/Adafruit BusIO @ 1.11.6
 	robtillaart/AM232X @ 0.4.1
-	enjoyneering/AHT10 @ 1.1.0
 	paulvha/sps30 @ 1.4.12
 	wifwaf/MH-Z19 @ 1.5.3
+	jcomas/S8_UART @ 1.0.1
 	sensirion/Sensirion Core @ 0.5.3
 	sensirion/Sensirion I2C SCD4x @ 0.3.1
+	https://github.com/enjoyneering/AHTxx.git#eb21571
 	https://github.com/hpsaturn/DHT_nonblocking.git#ec6e5b9
-	https://github.com/paulvha/SN-GCJA5.git
-	https://github.com/jcomas/S8_UART.git
-	https://github.com/jcomas/CM1106_UART.git
+	https://github.com/paulvha/SN-GCJA5.git#f261968
+	https://github.com/jcomas/CM1106_UART.git#da0eb4e	
 
 [common]
 framework = ${env.framework}

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1446,10 +1446,10 @@ void Sensors::bme680Init() {
 }
 
 void Sensors::aht10Init() {
-    sensorAnnounce(SENSORS::SAHT10);
-    aht10 = AHT10(AHT10_ADDRESS_0X38);
+    sensorAnnounce(SENSORS::SAHTXX);
+    aht10 = AHTxx(AHTXX_ADDRESS_X38, AHT1x_SENSOR);
     if (!aht10.begin()) return; 
-    sensorRegister(SENSORS::SAHT10);
+    sensorRegister(SENSORS::SAHTXX);
 }
 
 void Sensors::CO2scd30Init() {

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -240,23 +240,9 @@ uint16_t Sensors::getPM1() {
     return pm1;
 }
 
-/// @deprecated get PM1.0 ug/m3 formated value
-String Sensors::getStringPM1() {
-    char output[5];
-    sprintf(output, "%03d", getPM1());
-    return String(output);
-}
-
 /// get PM2.5 ug/m3 value
 uint16_t Sensors::getPM25() {
     return pm25;
-}
-
-/// @deprecated get PM2.5 ug/m3 formated value
-String Sensors::getStringPM25() {
-    char output[5];
-    sprintf(output, "%03d", getPM25());
-    return String(output);
 }
 
 /// get PM4 ug/m3 value
@@ -264,35 +250,14 @@ uint16_t Sensors::getPM4() {
     return pm4;
 }
 
-/// @deprecated get PM4 ug/m3 formated value
-String Sensors::getStringPM4() {
-    char output[5];
-    sprintf(output, "%03d", getPM4());
-    return String(output);
-}
-
 /// get PM10 ug/m3 value
 uint16_t Sensors::getPM10() {
     return pm10;
 }
 
-/// @deprecated get PM10 ug/m3 formated value
-String Sensors::getStringPM10() {
-    char output[5];
-    sprintf(output, "%03d", getPM10());
-    return String(output);
-}
-
 /// get CO2 ppm value
 uint16_t Sensors::getCO2() {
     return CO2Val;
-}
-
-/// @deprecated get CO2 ppm formated value
-String Sensors::getStringCO2() {
-    char output[5];
-    sprintf(output, "%04d", getCO2());
-    return String(output);
 }
 
 /// get humidity % value of CO2 sensor device

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -87,7 +87,7 @@ bool Sensors::readAllSensors() {
  * @param pms_rx (optional) UART PMS RX pin.
  * @param pms_tx (optional) UART PMS TX pin.
  */
-void Sensors::init(int pms_type, int pms_rx, int pms_tx) {
+void Sensors::init(u_int pms_type, int pms_rx, int pms_tx) {
 // override with debug INFO level (>=3)
 #ifdef CORE_DEBUG_LEVEL
     if (CORE_DEBUG_LEVEL >= 3) devmode = true;
@@ -350,7 +350,7 @@ uint8_t Sensors::getSensorsRegisteredCount() {
  * @return True if the sensor is registered, false otherwise.
  */
 bool Sensors::isSensorRegistered(SENSORS sensor) {
-    for (int i = 0; i < SCOUNT; i++) {
+    for (u_int i = 0; i < SCOUNT; i++) {
         if (sensors_registered[i] == sensor) return true;
     }
     return false;
@@ -398,7 +398,7 @@ uint8_t * Sensors::getSensorsRegistered() {
  */
 bool Sensors::isUnitRegistered(UNIT unit) {
     if (unit == UNIT::NUNIT) return false;
-    for (int i = 0; i < UCOUNT; i++) {
+    for (u_int i = 0; i < UCOUNT; i++) {
         if (units_registered[i] == unit) return true;
     }
     return false;
@@ -444,7 +444,7 @@ String Sensors::getUnitSymbol(UNIT unit) {
  * @return UNIT enum value.
  */
 UNIT Sensors::getNextUnit() {
-    for (int i = current_unit; i < UCOUNT; i++) {
+    for (u_int i = current_unit; i < UCOUNT; i++) {
         if (units_registered[i] != 0) {
             current_unit = i + 1;
             return (UNIT) units_registered[i];
@@ -462,7 +462,7 @@ UNIT Sensors::getNextUnit() {
  */
 void Sensors::resetUnitsRegister() {
     units_registered_count = 0;
-    for (int i = 0; i < UCOUNT; i++) {
+    for (u_int i = 0; i < UCOUNT; i++) {
         units_registered[i] = 0;
     }
 }
@@ -475,7 +475,7 @@ void Sensors::resetUnitsRegister() {
  */
 void Sensors::resetSensorsRegister() {
     sensors_registered_count = 0;
-    for (int i = 0; i < SCOUNT; i++) {
+    for (u_int i = 0; i < SCOUNT; i++) {
         sensors_registered[i] = 0;
     }
 }
@@ -563,7 +563,7 @@ void Sensors::printSensorsRegistered(bool debug) {
 void Sensors::printValues() {
     if (!devmode) return;
     Serial.print("-->[SLIB] Preview sensors values\t: ");
-    for (int i = 0; i < UCOUNT; i++) {
+    for (u_int i = 0; i < UCOUNT; i++) {
         if (units_registered[i] != 0) {
             Serial.print(getUnitName((UNIT)units_registered[i]));
             Serial.print(":");
@@ -1013,7 +1013,7 @@ void Sensors::sps30Errorloop(char *mess, uint8_t r) {
  * @param pms_rx PMS RX pin.
  * @param pms_tx PMS TX pin.
  **/
-bool Sensors::sensorSerialInit(int pms_type, int pms_rx, int pms_tx) {
+bool Sensors::sensorSerialInit(u_int pms_type, int pms_rx, int pms_tx) {
     // set UART for autodetection sensors (Honeywell, Plantower)
     if (pms_type == Auto) {
         DEBUG("-->[SLIB] UART detecting type\t: Auto");
@@ -1062,7 +1062,7 @@ bool Sensors::sensorSerialInit(int pms_type, int pms_rx, int pms_tx) {
  * In order UART config, this method looking up for
  * special header on Serial stream
  **/
-bool Sensors::pmSensorAutoDetect(int pms_type) {
+bool Sensors::pmSensorAutoDetect(u_int pms_type) {
     delay(1000);  // sync serial
 
     if (pms_type == SENSORS::SSPS30) {
@@ -1621,7 +1621,7 @@ void Sensors::disableWire1() {
 #endif
 }
 
-bool Sensors::serialInit(int pms_type, unsigned long speed_baud, int pms_rx, int pms_tx) {
+bool Sensors::serialInit(u_int pms_type, unsigned long speed_baud, int pms_rx, int pms_tx) {
     if(devmode)Serial.printf("-->[SLIB] UART init with speed\t: %lu RX:%i TX:%i\n", speed_baud, pms_rx, pms_tx);
     switch (SENSOR_COMMS) {
         case SERIALPORT:

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -1,7 +1,7 @@
 #ifndef Sensors_hpp
 #define Sensors_hpp
 
-#include <AHT10.h>
+#include <AHTxx.h>
 #include <AM232X.h>
 #include <Adafruit_BME280.h>
 #include <Adafruit_BME680.h>
@@ -120,7 +120,7 @@ typedef enum UNIT : size_t { SENSOR_UNITS } UNIT;
     X(SBME280, "BME280", 3) \
     X(SBMP280, "BMP280", 3) \
     X(SBME680, "BME680", 3) \
-    X(SAHT10, "AHT10", 3)   \
+    X(SAHTXX, "AHTXX", 3)   \
     X(SAM232X, "AM232X", 3) \
     X(SDHTX, "DHTX", 3)     \
     X(SCOUNT, "SCOUNT", 3)
@@ -180,7 +180,7 @@ class Sensors {
     // BME680 (Humidity, Gas, IAQ, Pressure, Altitude and Temperature)
     Adafruit_BME680 bme680;
     // AHT10
-    AHT10 aht10;
+    AHTxx aht10;
     // SHT31
     Adafruit_SHT31 sht31;
     // DHT sensor

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -207,7 +207,7 @@ class Sensors {
     // IKA Vindriktn sensor
     PM1006 *pm1006;
 
-    void init(int pms_type = 0, int pms_rx = PMS_RX, int pms_tx = PMS_TX);
+    void init(u_int pms_type = 0, int pms_rx = PMS_RX, int pms_tx = PMS_TX);
 
     void loop();
 
@@ -377,8 +377,8 @@ class Sensors {
 
     // UART sensors methods:
 
-    bool sensorSerialInit(int pms_type, int rx, int tx);
-    bool pmSensorAutoDetect(int pms_type);
+    bool sensorSerialInit(u_int pms_type, int rx, int tx);
+    bool pmSensorAutoDetect(u_int pms_type);
     bool pmSensorRead();
     bool pmGenericRead();
     bool pmGCJA5Read();
@@ -409,7 +409,7 @@ class Sensors {
 
     void disableWire1();
 
-    bool serialInit(int pms_type, unsigned long speed_baud, int pms_rx, int pms_tx);
+    bool serialInit(u_int pms_type, unsigned long speed_baud, int pms_rx, int pms_tx);
 
     String hwSerialRead(unsigned int lenght_buffer);
 

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -18,8 +18,8 @@
 #include <sps30.h>
 #include <drivers/pm1006.h>
 
-#define CSL_VERSION "0.5.9"
-#define CSL_REVISION 366
+#define CSL_VERSION "0.6.0"
+#define CSL_REVISION 368
 
 /***************************************************************
 * S E T U P   E S P 3 2   B O A R D S   A N D   F I E L D S

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -18,8 +18,8 @@
 #include <sps30.h>
 #include <drivers/pm1006.h>
 
-#define CSL_VERSION "0.5.8"
-#define CSL_REVISION 364
+#define CSL_VERSION "0.5.9"
+#define CSL_REVISION 366
 
 /***************************************************************
 * S E T U P   E S P 3 2   B O A R D S   A N D   F I E L D S

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -259,28 +259,6 @@ class Sensors {
 
     void setSeaLevelPressure(float hpa);
 
-    String getFormatTemp();
-
-    String getFormatPress();
-
-    String getFormatHum();
-
-    String getFormatGas();
-
-    String getFormatAlt();
-
-    String getStringPM1();
-
-    String getStringPM25();
-
-    String getStringPM4();
-
-    String getStringPM10();
-
-    String getStringCO2();
-
-    String getStringCO2temp();
-
     void setCO2RecalibrationFactor(int ppmValue);
 
     void detectI2COnly(bool enable);


### PR DESCRIPTION
- [x] suppressed warnings on Atmel SAM and ESP8266 for PMS Type
- [x] migrated AHT10 library to AHTxx (suggested for the same author)
- [x] fixed library version (git libraries)
- [x] migrated S8 library dependency to PlatformIO registry
- [x] removed all **deprecated** methods **Please review your implementation**

## Tested on

- [x] CanAirIO Bike version
- [x] M5Core Ink basic air quality station
- [x] M5StickCPlus CanAirIO version
  