### PR TITLE
cambio direccion i2c nh3 y co

### DIFF
--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1580,7 +1580,7 @@ void Sensors::GCJA5Init() {
 
 void Sensors::DFRobotCOInit() {
   sensorAnnounce(SENSORS::SDFRCO);
-  dfrCO = DFRobot_GAS_I2C(&Wire, 0x74);
+  dfrCO = DFRobot_GAS_I2C(&Wire, 0x78);
   if (!dfrCO.begin()) return;
   //Mode of obtaining data: the main controller needs to request the sensor for data
   dfrCO.changeAcquireMode(dfrCO.PASSIVITY);
@@ -1591,7 +1591,7 @@ void Sensors::DFRobotCOInit() {
 
 void Sensors::DFRobotNH3Init() {
   sensorAnnounce(SENSORS::SDFRNH3);
-  dfrNH3 = DFRobot_GAS_I2C(&Wire, 0x76); // 0x77 y 0x75 used by bme680
+  dfrNH3 = DFRobot_GAS_I2C(&Wire, 0x7A); // 0x77 y 0x75 used by bme680
   if (!dfrNH3.begin()) return;
   //Mode of obtaining data: the main controller needs to request the sensor for data
   dfrNH3.changeAcquireMode(dfrNH3.PASSIVITY);

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1580,7 +1580,7 @@ void Sensors::GCJA5Init() {
 
 void Sensors::DFRobotCOInit() {
   sensorAnnounce(SENSORS::SDFRCO);
-  dfrCO = DFRobot_GAS_I2C(&Wire, 0x78);
+  dfrCO = DFRobot_GAS_I2C(&Wire, 0x78); // Be sure that your group of i2c address is 7
   if (!dfrCO.begin()) return;
   //Mode of obtaining data: the main controller needs to request the sensor for data
   dfrCO.changeAcquireMode(dfrCO.PASSIVITY);
@@ -1591,7 +1591,7 @@ void Sensors::DFRobotCOInit() {
 
 void Sensors::DFRobotNH3Init() {
   sensorAnnounce(SENSORS::SDFRNH3);
-  dfrNH3 = DFRobot_GAS_I2C(&Wire, 0x7A); // 0x77 y 0x75 used by bme680
+  dfrNH3 = DFRobot_GAS_I2C(&Wire, 0x7A); // 0x77 y 0x75 used by bme680. Be sure that your group of i2c address is 7
   if (!dfrNH3.begin()) return;
   //Mode of obtaining data: the main controller needs to request the sensor for data
   dfrNH3.changeAcquireMode(dfrNH3.PASSIVITY);


### PR DESCRIPTION
Cambiado al grupo 7 las direcciones i2c.
Se pueden usar 0x78 0x79 0x7A y 0x7B.
Queda configurados los switchs con las direcciones 0x78 para CO y 0x7A para nh3.
Evita conflictos con las direcciones de los sensores BMP280, BME280, BME680.

