### PR TITLE
Fix issue with Sensors::setTempOffset() for SCD30

### DIFF
--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -384,7 +384,7 @@ void Sensors::tempRegister(bool isCO2temp) {
  */
 void Sensors::setTempOffset(float offset) {
   toffset = offset;
-  setSCD30TempOffset(toffset);
+  setSCD30TempOffset(toffset * 100);
   setSCD4xTempOffset(toffset);
   setsen5xTempOffset(toffset);
 }


### PR DESCRIPTION
I tested it with a SCD30 and it's working fine at my end.