### PR TITLE
Fix void Sensors::CO2scd30Read(). Add fast return if not registered #197

### DIFF
--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -986,6 +986,7 @@ void Sensors::sht31Read() {
 }
 
 void Sensors::CO2scd30Read() {
+  if (!isSensorRegistered(SENSORS::SSCD30)) return;
   if (!scd30.dataReady() || !scd30.read()) return;
   uint16_t tCO2 = scd30.CO2;  // we need temp var, without it override CO2
   if (tCO2 > 0) {


### PR DESCRIPTION
## Description

CO2scd30Read() was taking around 1 second to return, even if the SCD30 sensor wasn't registered.

## Related Issues

Issue with Sensors::CO2scd30Read() #197 

## Tests

Tested with SCD30 and SCD41 on CO2 Gadget. Looks to work fine with both.