### PR TITLE
Fix offset

### DIFF
--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1629,6 +1629,7 @@ void Sensors::CO2scd4xInit() {
   scd4x.begin(Wire);
   error = scd4x.stopPeriodicMeasurement();
   if (error) return;
+  sensorRegister(SENSORS::SSCD4X);
   scd4x.getTemperatureOffset(tTemperatureOffset);
   scd4x.getSensorAltitude(tSensorAltitude);
   DEBUG("-->[SLIB] SCD4x Temp offset\t:", String(tTemperatureOffset).c_str());
@@ -1644,7 +1645,6 @@ void Sensors::CO2scd4xInit() {
   }
   error = scd4x.startPeriodicMeasurement();
   if (error) DEBUG("[W][SLIB] SCD4x periodic measure\t: starting error:", String(error).c_str());
-  sensorRegister(SENSORS::SSCD4X);
 }
 
 /// set SCD4x temperature compensation

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1586,6 +1586,8 @@ void Sensors::CO2scd30Init() {
 #endif
   delay(10);
 
+  sensorRegister(SENSORS::SSCD30);
+
   DEBUG("-->[SLIB] SCD30 Temp offset\t:", String(scd30.getTemperatureOffset()).c_str());
   DEBUG("-->[SLIB] SCD30 Altitude offset\t:", String(scd30.getAltitudeOffset()).c_str());
 
@@ -1595,11 +1597,10 @@ void Sensors::CO2scd30Init() {
     delay(10);
   }
 
-  if (uint16_t((scd30.getTemperatureOffset() * 100)) != (uint16_t(toffset * 100))) {
+  if (uint16_t((scd30.getTemperatureOffset())) != (uint16_t(toffset * 100))) {
     setSCD30TempOffset(toffset);
     delay(10);
   }
-  sensorRegister(SENSORS::SSCD30);
 }
 
 /// set SCD30 temperature compensation

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1598,6 +1598,7 @@ void Sensors::CO2scd30Init() {
   }
 
   if (uint16_t((scd30.getTemperatureOffset())) != (uint16_t(toffset * 100))) {
+    DEBUG("-->[SLIB] SCD30 Temp offset to\t:", String(toffset).c_str());
     setSCD30TempOffset(toffset);
     delay(10);
   }


### PR DESCRIPTION
## Description

I moved the sensor registration up in Sensors::CO2scd30Init() and Sensors::CO2scd4xInit() to fix (2).

I don't see any side effects. Tested with both sensors in CO2 Gadget and looks like it's working fine.

In Sensors::CO2scd30Init() I also changed In Sensors::CO2scd30Init() to multiply toffset * 100 to convert into hundredths of a degree C to comply with Sensirion's API.

Maybe we should do the same for Sensors::sen5xInit() but I don't have one to test.

## Related Issues

This is one partial fix for issue #203

## Tests

I added the following tests:

I don't see any side effects. Tested with both sensors in CO2 Gadget and looks like it's working fine.