### PR TITLE
Add internal temperature offset initialization and retrieval methods

### DIFF
--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -354,6 +354,21 @@ void Sensors::tempRegister(bool isCO2temp) {
 }
 
 /**
+ * @brief Initialize internal temperature offset to be used on startup
+ *
+ * Positive value for offset to be subtracetd to the temperature.
+ * Mush be called before the initialization of the sensors.
+ */
+void Sensors::initTOffset(float offset) { toffset = offset; }
+
+/**
+ * @brief Get sensorlib actual internal temperature offset
+ * @return float with the temperature offset.
+ * Positive value for offset to be subtracetd to the temperature.
+ */
+float Sensors::getTOffset() { return toffset; }
+
+/**
  * @brief Set temperature offset for all temperature sensors
  *
  * Positive value for offset to be subtracetd to the temperature.

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -304,6 +304,10 @@ class Sensors {
 
   float getGeigerMicroSievertHour(void);
 
+  void initTOffset(float offset);
+
+  float getTOffset();
+
   void setTempOffset(float offset);
 
   float getTempOffset();


### PR DESCRIPTION
## Description

The programmer using the library must set the float variable sensors.toffset, prior to sensors.init(), to the same temperature offset the program using the library has stored as "actual offset temperature" for everything to be "on sync".

This implements methods to set and retrieve this variable. This must be called before calling sensors.init().

## Related Issues

#203 

## Tests

Tested on CO2 Gadget without detecting any issues.