### PR TITLE
fix: DFRobot gas sensors — external T/P compensation, fixed I2C addresses, and low-concentration fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,20 +62,20 @@ Panasonic via UART in ESP8266 maybe needs select in detection.
 NOTE:  
 DHT22 is supported but is not recommended. Please see the documentation.  
 
-#### DFRobot Gravity gas (SEN0465–SEN0476 electrochemical vs MEMS MiCS)
+#### DFRobot Gravity gas sensors
 
 - **Librería (fabricante):** [DFRobot_MultiGasSensor](https://github.com/DFRobot/DFRobot_MultiGasSensor) — la dependencia PlatformIO está en `unified-lib-deps.ini` apuntando a ese repositorio.
-- **SEN0466 (CO)** y **SEN0472 (O₃)** usan I²C **0x74–0x77** según interruptores A0/A1 (ver [wiki DFRobot](https://wiki.dfrobot.com/SKU_SEN0465toSEN0476_Gravity_Gas_Sensor_Calibrated_I2C_UART)). Por defecto el firmware usa **CO @ 0x74** y **O₃ @ 0x75**: pon el módulo de ozono en **ADDRESS_1** para que no comparta **0x74** con el CO.
-- No uses `changeI2cAddrGroup` con estos sensores salvo el flujo MEMS antiguo; el firmware **no** aplica ese paso salvo que actives el modo legacy.
-- **Modo legacy MEMS** (direcciones 0x78–0x7B): en `platformio.ini` del proyecto,  
-  `build_flags = -D DFROBOT_MEMS_LEGACY_GROUP7=1`
-- Direcciones personalizadas:  
-  `build_flags = -D DFROBOT_CO_I2C_ADDR=0x76 -D DFROBOT_O3_I2C_ADDR=0x77` (ajusta según DIP y evita conflicto con BME680 en **0x77**).
-- Precalentamiento: la wiki recomienda **>5 min** al encender (y hasta 24 h si el sensor estuvo mucho tiempo parado).
-
-**Alineación [documentación CanAirIO (DFRobot)](https://canair.io/docs/dfrobot_sensors.html):** esa guía asume **grupo I²C 7** (p. ej. CO `0x78`, NH3 `0x7A`, NO2 `0x7B`) y el uso de `changeI2cAddrGroup(7)` (o el sketch previo). Para replicar ese comportamiento en sensorlib usa  
-`build_flags = -D DFROBOT_MEMS_LEGACY_GROUP7=1`  
-y revisa `docs/CanAirIO_DFRobot_alignment.md`. El valor por defecto (`LEGACY_GROUP7=0`, direcciones `0x74`/`0x75`) sigue la wiki DFRobot para sensores en grupo 6 sin el paso de CanAirIO.
+- **Direcciones I²C fijas (grupo 7):**  
+  | Sensor | Dirección | Referencia |
+  |--------|-----------|------------|
+  | CO     | 0x78      | SEN0466    |
+  | O₃     | 0x79      | SEN0472    |
+  | NH₃    | 0x7A      | SEN0469    |
+  | NO₂    | 0x7B      | SEN0471    |
+- **Direcciones personalizadas:** se puede sobreescribir cualquier dirección vía `build_flags`, p. ej.:  
+  `build_flags = -D DFROBOT_CO_I2C_ADDR=0x74`
+- **Precalentamiento:** la wiki recomienda **>5 min** al encender (y hasta 24 h si el sensor estuvo mucho tiempo parado).
+- **Compensación:** la librería aplica compensación propia de temperatura y presión utilizando sensores externos (BME280, etc.) o la temperatura interna del propio DFRobot si no hay sensor externo disponible.
 
 NoiseSensor auto-detection usa el mismo bus I2C que el resto de sensores (Wire) y está disponible solo en ESP32-C3, ESP32-S2 y ESP32-S3.
 

--- a/examples/advanced_multivariable/src/main.cpp
+++ b/examples/advanced_multivariable/src/main.cpp
@@ -77,10 +77,10 @@ void setup() {
   Serial.println("\n== Sensor test setup ==\n");
   Serial.println("-->[SETUP] Detecting sensors..");
 
-  sensors.setSampleTime(10);                     // config sensors sample time interval
-  sensors.setOnDataCallBack(&onSensorDataOk);    // all data read callback
-  sensors.setDebugMode(true);                    // [optional] debug mode
-  sensors.detectI2COnly(false);                  // not force to only i2c sensors
+  sensors.setSampleTime(10);                   // config sensors sample time interval
+  sensors.setOnDataCallBack(&onSensorDataOk);  // all data read callback
+  sensors.setDebugMode(true);                  // [optional] debug mode
+  sensors.detectI2COnly(false);                // not force to only i2c sensors
   // sensors.setTemperatureUnit(TEMPUNIT::KELVIN);  // comment for Celsius or set Fahrenheit
   // sensors.init(SENSORS::Auto, 13, 12);          // Auto detection (Custom UART sensor pins
   // example)

--- a/examples/test_noise_max4466/src/main.cpp
+++ b/examples/test_noise_max4466/src/main.cpp
@@ -1,18 +1,19 @@
 /*
  * Test Example: MAX4466 Noise Sensor with CanAirIO SensorLib
- * 
+ *
  * This example demonstrates how to read noise data from the MAX4466
  * I2C slave device using the CanAirIO SensorLib framework.
- * 
+ *
  * Hardware connections:
  * - Master SDA -> Slave GPIO 8
  * - Master SCL -> Slave GPIO 10
  * - GND -> GND
- * 
+ *
  * Platform: ESP32-S3 or ESP32 (master)
  */
 
 #include <Arduino.h>
+
 #include <Sensors.hpp>
 
 // Callback cuando los datos del sensor están listos
@@ -20,43 +21,43 @@ void onSensorDataOk() {
   Serial.println("\n=================================");
   Serial.println("  NOISE SENSOR MEASUREMENTS");
   Serial.println("=================================");
-  
+
   // Mediciones instantáneas
   Serial.print("Instant Noise:  ");
   Serial.print(sensors.getNoise());
   Serial.println(" dB");
-  
+
   Serial.print("Average:        ");
   Serial.print(sensors.getNoiseAverage());
   Serial.println(" dB");
-  
+
   Serial.print("Peak:           ");
   Serial.print(sensors.getNoisePeak());
   Serial.println(" dB");
-  
+
   Serial.print("Minimum:        ");
   Serial.print(sensors.getNoiseMin());
   Serial.println(" dB");
-  
+
   Serial.println("\n--- Regulatory Indicators ---");
-  
+
   // Indicadores normativos
   Serial.print("Ld (Day):       ");
   Serial.print(sensors.getNoiseLd());
   Serial.println(" dB  [07:00-19:00]");
-  
+
   Serial.print("Le (Evening):   ");
   Serial.print(sensors.getNoiseLe());
   Serial.println(" dB  [19:00-23:00]");
-  
+
   Serial.print("Ln (Night):     ");
   Serial.print(sensors.getNoiseLn());
   Serial.println(" dB  [23:00-07:00]");
-  
+
   Serial.print("Lden (Global):  ");
   Serial.print(sensors.getNoiseLden());
   Serial.println(" dB  [24h index]");
-  
+
   Serial.println("=================================\n");
 }
 
@@ -69,48 +70,48 @@ void onSensorDataError(const char *msg) {
 void setup() {
   Serial.begin(115200);
   delay(2000);
-  
+
   Serial.println("\n\n");
   Serial.println("╔══════════════════════════════════════╗");
   Serial.println("║  MAX4466 Noise Sensor Test          ║");
   Serial.println("║  CanAirIO SensorLib Integration     ║");
   Serial.println("╚══════════════════════════════════════╝");
   Serial.println();
-  
+
   // Configurar callbacks
   sensors.setOnDataCallBack(&onSensorDataOk);
   sensors.setOnErrorCallBack(&onSensorDataError);
-  
+
   // Configurar modo debug
   sensors.setDebugMode(true);
-  
+
   // Forzar detección solo I2C (no UART)
   sensors.detectI2COnly(true);
-  
+
   // Sample time en segundos
   sensors.setSampleTime(5);
-  
+
   Serial.println("[INFO] Initializing sensors...");
   sensors.init();
-  
+
   delay(2000);
-  
+
   // Sincronizar tiempo (opcional pero recomendado para Ld/Le/Ln/Lden)
   // Aquí usamos un timestamp de ejemplo (2024-02-11 12:00:00 UTC)
   // En producción, obtener de RTC o NTP
-  uint32_t testTimestamp = 1707652800;  
-  
+  uint32_t testTimestamp = 1707652800;
+
   Serial.println("\n[INFO] Synchronizing time with sensor...");
   Serial.print("[INFO] Sending timestamp: ");
   Serial.println(testTimestamp);
-  
+
   if (sensors.sendNoiseSensorTime(testTimestamp)) {
     Serial.println("[OK] Time synchronized successfully!");
     Serial.println("[INFO] Sensor will now calculate Ld, Le, Ln based on time periods");
   } else {
     Serial.println("[WARNING] Time sync failed - Ld/Le/Ln/Lden will remain at 0");
   }
-  
+
   Serial.println("\n[INFO] Starting data acquisition...\n");
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,6 @@ build_flags =
 	-D ARDUINO_ESP32_DEV=1
 	-Wall
 	-Wextra
- 	-D DFROBOT_MEMS_LEGACY_GROUP7=1
 
 [common]
 framework = ${env.framework}
@@ -57,7 +56,6 @@ build_flags =
 	-D CORE_DEBUG_LEVEL=1
 	-D ARDUINO_ESP8266_ESP12E=1
 	-D INCLUDE_SOFTWARE_SERIAL=1
-	-D DFROBOT_MEMS_LEGACY_GROUP7=1
 
 [env:esp32]
 extends = esp32_common

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -9,11 +9,8 @@
 #endif
 
 static void dfrGasBeginFailed(const char *gasName, uint8_t i2cAddr) {
-  Serial.printf(
-      "[W][SLIB] DFRobot %s begin failed — I2C 0x%02X (wiring/DIP; try -D "
-      "DFROBOT_MEMS_LEGACY_GROUP7=0 or "
-      "=1)\r\n",
-      gasName, i2cAddr);
+  Serial.printf("[W][SLIB] DFRobot %s begin failed — I2C 0x%02X\r\n",
+                gasName, i2cAddr);
 }
 
 // Units and sensors registers
@@ -2315,17 +2312,6 @@ float Sensors::dfrGasPressCompensation(float ppm, float pressure) {
 /// DFRobot GAS (CO) sensors init
 void Sensors::DFRobotCOInit() {
   sensorAnnounce(SENSORS::SDFRCO);
-#if DFROBOT_MEMS_LEGACY_GROUP7
-  // MEMS MiCS only: move I2C group 6 (0x74-0x77) -> group 7 (0x78-0x7B). Not for SEN0466/SEN0472.
-  for (uint8_t addr = 0x74; addr <= 0x77; addr++) {
-    DFRobot_GAS_I2C temp(&Wire, addr);
-    if (temp.begin()) {
-      temp.changeI2cAddrGroup(7);
-      delay(200);
-    }
-  }
-  delay(300);
-#endif
   dfrCO = DFRobot_GAS_I2C(&Wire, DFROBOT_CO_I2C_ADDR);
   if (!dfrCO.begin()) {
     dfrGasBeginFailed("CO", DFROBOT_CO_I2C_ADDR);

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1290,12 +1290,13 @@ void Sensors::DFRobotNH3Read() {
   if (!isSensorRegistered(SENSORS::SDFRNH3)) return;
   float rawPpm = dfrNH3.readGasConcentrationPPM();
   float dfrInternalTemp = dfrNH3.readTempC();
-  float compensationTemp = (temp != 0.0) ? temp : (dfrInternalTemp - toffset);
+  bool hasExternalTempSensor = dfrHasExternalTempSensor();
+  float compensationTemp = hasExternalTempSensor ? temp : (dfrInternalTemp - toffset);
   nh3 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::NH3);
   if (pres > 0.0) nh3 = dfrGasPressCompensation(nh3, pres);
   unitRegister(UNIT::NH3);
   dataReady = true;
-  if (temp == 0.0) {
+  if (!hasExternalTempSensor) {
     temp = dfrInternalTemp - toffset;
     tempRegister(false);
   }
@@ -1305,12 +1306,13 @@ void Sensors::DFRobotCORead() {
   if (!isSensorRegistered(SENSORS::SDFRCO)) return;
   float rawPpm = dfrCO.readGasConcentrationPPM();
   float dfrInternalTemp = dfrCO.readTempC();
-  float compensationTemp = (temp != 0.0) ? temp : (dfrInternalTemp - toffset);
+  bool hasExternalTempSensor = dfrHasExternalTempSensor();
+  float compensationTemp = hasExternalTempSensor ? temp : (dfrInternalTemp - toffset);
   co = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::CO);
   if (pres > 0.0) co = dfrGasPressCompensation(co, pres);
   unitRegister(UNIT::CO);
   dataReady = true;
-  if (temp == 0.0) {
+  if (!hasExternalTempSensor) {
     temp = dfrInternalTemp - toffset;
     tempRegister(false);
   }
@@ -1320,12 +1322,13 @@ void Sensors::DFRobotNO2Read() {
   if (!isSensorRegistered(SENSORS::SDFRNO2)) return;
   float rawPpm = dfrNO2.readGasConcentrationPPM();
   float dfrInternalTemp = dfrNO2.readTempC();
-  float compensationTemp = (temp != 0.0) ? temp : (dfrInternalTemp - toffset);
+  bool hasExternalTempSensor = dfrHasExternalTempSensor();
+  float compensationTemp = hasExternalTempSensor ? temp : (dfrInternalTemp - toffset);
   no2 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::NO2);
   if (pres > 0.0) no2 = dfrGasPressCompensation(no2, pres);
   unitRegister(UNIT::NO2);
   dataReady = true;
-  if (temp == 0.0) {
+  if (!hasExternalTempSensor) {
     temp = dfrInternalTemp - toffset;
     tempRegister(false);
   }
@@ -1335,12 +1338,13 @@ void Sensors::DFRobotO3Read() {
   if (!isSensorRegistered(SENSORS::SDFRO3)) return;
   float rawPpm = dfrO3.readGasConcentrationPPM();
   float dfrInternalTemp = dfrO3.readTempC();
-  float compensationTemp = (temp != 0.0) ? temp : (dfrInternalTemp - toffset);
+  bool hasExternalTempSensor = dfrHasExternalTempSensor();
+  float compensationTemp = hasExternalTempSensor ? temp : (dfrInternalTemp - toffset);
   o3 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::O3);
   if (pres > 0.0) o3 = dfrGasPressCompensation(o3, pres);
   unitRegister(UNIT::O3);
   dataReady = true;
-  if (temp == 0.0) {
+  if (!hasExternalTempSensor) {
     temp = dfrInternalTemp - toffset;
     tempRegister(false);
   }
@@ -2138,9 +2142,9 @@ float Sensors::getSCD4xTempOffset() const {
     uint16_t error = nonConstThis->scd4x.stopPeriodicMeasurement();
     if (error) {
       DEBUG("[SLIB] SCD4x stopPeriodicMeasurement()\t: error:", String(error).c_str());
-      return 0.0;
+    } else {
+      nonConstThis->scd4x.getTemperatureOffset(offset);
     }
-    nonConstThis->scd4x.getTemperatureOffset(offset);
     nonConstThis->scd4x.startPeriodicMeasurement();
   }
   return offset;
@@ -2204,6 +2208,26 @@ void Sensors::GCJA5Init() {
 }
 
 /**
+ * @brief Check if any non-DFRobot sensor that provides ambient temperature
+ *        is registered and read before the DFRobot sensors in readAllSensors().
+ *
+ * Unlike checking isUnitRegistered(UNIT::TEMP), this avoids a subtle bug:
+ * the first DFRobot read in a cycle would register UNIT::TEMP itself, causing
+ * all subsequent DFRobot reads (and all future cycles) to believe an external
+ * sensor is present and stop refreshing the temperature from readTempC().
+ */
+bool Sensors::dfrHasExternalTempSensor() const {
+  return isSensorRegistered(SENSORS::SBME280) ||
+         isSensorRegistered(SENSORS::SBMP280) ||
+         isSensorRegistered(SENSORS::SBME680) ||
+         isSensorRegistered(SENSORS::SSHT31) ||
+         isSensorRegistered(SENSORS::SAHTXX) ||
+         isSensorRegistered(SENSORS::SAM232X) ||
+         isSensorRegistered(SENSORS::SSEN5X) ||
+         isSensorRegistered(SENSORS::P5003T);
+}
+
+/**
  * @brief Temperature compensation for DFRobot gas sensors using external temperature.
  *
  * Reimplements the DFRobot library formulas (from DFRobot_MultiGasSensor.cpp)
@@ -2217,6 +2241,12 @@ void Sensors::GCJA5Init() {
  * @return Compensated gas concentration in PPM
  */
 float Sensors::dfrGasTempCompensation(float rawPpm, float temperature, uint8_t gasType) {
+  static const float DFR_TEMP_MIN = -20.0f;
+  static const float DFR_TEMP_MAX = 40.0f;
+
+  if (temperature <= DFR_TEMP_MIN) temperature = DFR_TEMP_MIN + 0.01f;
+  if (temperature > DFR_TEMP_MAX) temperature = DFR_TEMP_MAX;
+
   float compensated = rawPpm;
 
   switch (gasType) {

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -796,7 +796,7 @@ void Sensors::printValues() {
       Serial.print(getUnitName(unit));
       Serial.print(":");
       bool isGasPpm = (unit == NH3 || unit == CO || unit == NO2 || unit == O3);
-      Serial.printf(isGasPpm ? "%02.2f " : "%02.1f ", getUnitValue(unit));
+      Serial.printf(isGasPpm ? "%02.2f " : "%02.2f ", getUnitValue(unit));
     }
   }
   Serial.println();

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -2232,6 +2232,11 @@ bool Sensors::dfrHasExternalTempSensor() const {
  * (BME280, SHT31, etc.) instead of the stale onboard thermistor value that
  * the library captures only once at init.
  *
+ * Each formula is split into a gain divisor (corrects sensitivity drift) and
+ * a baseline offset (corrects zero-point drift).  When the offset would make
+ * the result negative — common for low ambient NO2/O3/CO concentrations — we
+ * fall back to the gain-only correction so the reading stays meaningful.
+ *
  * @param rawPpm  Uncompensated gas concentration from readGasConcentrationPPM()
  * @param temperature  Ambient temperature in °C (from external sensor)
  * @param gasType  DFRobot gas type constant (DFRobot_GAS::CO, ::NH3, ::NO2, ::O3)
@@ -2244,44 +2249,49 @@ float Sensors::dfrGasTempCompensation(float rawPpm, float temperature, uint8_t g
   if (temperature <= DFR_TEMP_MIN) temperature = DFR_TEMP_MIN + 0.01f;
   if (temperature > DFR_TEMP_MAX) temperature = DFR_TEMP_MAX;
 
-  float compensated = rawPpm;
+  float gainDivisor = 1.0f;
+  float baselineOffset = 0.0f;
 
   switch (gasType) {
     case DFRobot_GAS::CO:
-      if (temperature > -20 && temperature <= 20) {
-        compensated = rawPpm / (0.005 * temperature + 0.9);
-      } else if (temperature > 20 && temperature <= 40) {
-        compensated = rawPpm / (0.005 * temperature + 0.9) - (0.3 * temperature - 6);
-      }
+      gainDivisor = 0.005f * temperature + 0.9f;
+      if (temperature > 20) baselineOffset = 0.3f * temperature - 6.0f;
       break;
 
     case DFRobot_GAS::NH3:
-      if (temperature > -20 && temperature <= 0) {
-        compensated = rawPpm / (0.006 * temperature + 0.95) - (-0.006 * temperature + 0.25);
-      } else if (temperature > 0 && temperature <= 20) {
-        compensated = rawPpm / (0.006 * temperature + 0.95) - (-0.012 * temperature + 0.25);
-      } else if (temperature > 20 && temperature <= 40) {
-        compensated = rawPpm / (0.005 * temperature + 1.08) - (-0.1 * temperature + 2);
+      if (temperature <= 0) {
+        gainDivisor = 0.006f * temperature + 0.95f;
+        baselineOffset = -0.006f * temperature + 0.25f;
+      } else if (temperature <= 20) {
+        gainDivisor = 0.006f * temperature + 0.95f;
+        baselineOffset = -0.012f * temperature + 0.25f;
+      } else {
+        gainDivisor = 0.005f * temperature + 1.08f;
+        baselineOffset = -0.1f * temperature + 2.0f;
       }
       break;
 
     case DFRobot_GAS::NO2:
-      if (temperature > -20 && temperature <= 0) {
-        compensated = rawPpm / (0.005 * temperature + 0.9) - (-0.0025 * temperature + 0.005);
-      } else if (temperature > 0 && temperature <= 20) {
-        compensated = rawPpm / (0.005 * temperature + 0.9) - (0.005 * temperature + 0.005);
-      } else if (temperature > 20 && temperature <= 40) {
-        compensated = rawPpm / (0.005 * temperature + 0.9) - (0.0025 * temperature + 0.1);
+      gainDivisor = 0.005f * temperature + 0.9f;
+      if (temperature <= 0) {
+        baselineOffset = -0.0025f * temperature + 0.005f;
+      } else if (temperature <= 20) {
+        baselineOffset = 0.005f * temperature + 0.005f;
+      } else {
+        baselineOffset = 0.0025f * temperature + 0.1f;
       }
       break;
 
     case DFRobot_GAS::O3:
-      if (temperature > -20 && temperature <= 0) {
-        compensated = rawPpm / (0.015 * temperature + 1.1) - 0.05;
-      } else if (temperature > 0 && temperature <= 20) {
-        compensated = rawPpm / 1.1 - (0.01 * temperature);
-      } else if (temperature > 20 && temperature <= 40) {
-        compensated = rawPpm / 1.1 - (-0.005 * temperature + 0.3);
+      if (temperature <= 0) {
+        gainDivisor = 0.015f * temperature + 1.1f;
+        baselineOffset = 0.05f;
+      } else if (temperature <= 20) {
+        gainDivisor = 1.1f;
+        baselineOffset = 0.01f * temperature;
+      } else {
+        gainDivisor = 1.1f;
+        baselineOffset = -0.005f * temperature + 0.3f;
       }
       break;
 
@@ -2289,7 +2299,11 @@ float Sensors::dfrGasTempCompensation(float rawPpm, float temperature, uint8_t g
       break;
   }
 
-  return (compensated >= 0) ? compensated : 0.0f;
+  float scaled = rawPpm / gainDivisor;
+  float compensated = scaled - baselineOffset;
+
+  if (compensated < 0) return (scaled > 0) ? scaled : 0.0f;
+  return compensated;
 }
 
 /**

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -792,9 +792,11 @@ void Sensors::printValues() {
   Serial.print("-->[SLIB] sensors values  \t: ");
   for (u_int i = 0; i < UCOUNT; i++) {
     if (units_registered[i] != 0) {
-      Serial.print(getUnitName((UNIT)units_registered[i]));
+      UNIT unit = (UNIT)units_registered[i];
+      Serial.print(getUnitName(unit));
       Serial.print(":");
-      Serial.printf("%02.1f ", getUnitValue((UNIT)units_registered[i]));
+      bool isGasPpm = (unit == NH3 || unit == CO || unit == NO2 || unit == O3);
+      Serial.printf(isGasPpm ? "%02.2f " : "%02.1f ", getUnitValue(unit));
     }
   }
   Serial.println();

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -9,8 +9,7 @@
 #endif
 
 static void dfrGasBeginFailed(const char *gasName, uint8_t i2cAddr) {
-  Serial.printf("[W][SLIB] DFRobot %s begin failed — I2C 0x%02X\r\n",
-                gasName, i2cAddr);
+  Serial.printf("[W][SLIB] DFRobot %s begin failed — I2C 0x%02X\r\n", gasName, i2cAddr);
 }
 
 // Units and sensors registers
@@ -2216,14 +2215,10 @@ void Sensors::GCJA5Init() {
  * sensor is present and stop refreshing the temperature from readTempC().
  */
 bool Sensors::dfrHasExternalTempSensor() const {
-  return isSensorRegistered(SENSORS::SBME280) ||
-         isSensorRegistered(SENSORS::SBMP280) ||
-         isSensorRegistered(SENSORS::SBME680) ||
-         isSensorRegistered(SENSORS::SSHT31) ||
-         isSensorRegistered(SENSORS::SAHTXX) ||
-         isSensorRegistered(SENSORS::SAM232X) ||
-         isSensorRegistered(SENSORS::SSEN5X) ||
-         isSensorRegistered(SENSORS::P5003T);
+  return isSensorRegistered(SENSORS::SBME280) || isSensorRegistered(SENSORS::SBMP280) ||
+         isSensorRegistered(SENSORS::SBME680) || isSensorRegistered(SENSORS::SSHT31) ||
+         isSensorRegistered(SENSORS::SAHTXX) || isSensorRegistered(SENSORS::SAM232X) ||
+         isSensorRegistered(SENSORS::SSEN5X) || isSensorRegistered(SENSORS::P5003T);
 }
 
 /**

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1288,44 +1288,60 @@ void Sensors::GCJA5Read() {
 
 void Sensors::DFRobotNH3Read() {
   if (!isSensorRegistered(SENSORS::SDFRNH3)) return;
-  nh3 = dfrNH3.readGasConcentrationPPM();
+  float rawPpm = dfrNH3.readGasConcentrationPPM();
+  float dfrInternalTemp = dfrNH3.readTempC();
+  float compensationTemp = (temp != 0.0) ? temp : (dfrInternalTemp - toffset);
+  nh3 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::NH3);
+  if (pres > 0.0) nh3 = dfrGasPressCompensation(nh3, pres);
   unitRegister(UNIT::NH3);
   dataReady = true;
   if (temp == 0.0) {
-    temp = dfrNH3.readTempC() - toffset;
+    temp = dfrInternalTemp - toffset;
     tempRegister(false);
   }
 }
 
 void Sensors::DFRobotCORead() {
   if (!isSensorRegistered(SENSORS::SDFRCO)) return;
-  co = dfrCO.readGasConcentrationPPM();
+  float rawPpm = dfrCO.readGasConcentrationPPM();
+  float dfrInternalTemp = dfrCO.readTempC();
+  float compensationTemp = (temp != 0.0) ? temp : (dfrInternalTemp - toffset);
+  co = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::CO);
+  if (pres > 0.0) co = dfrGasPressCompensation(co, pres);
   unitRegister(UNIT::CO);
   dataReady = true;
   if (temp == 0.0) {
-    temp = dfrCO.readTempC() - toffset;
+    temp = dfrInternalTemp - toffset;
     tempRegister(false);
   }
 }
 
 void Sensors::DFRobotNO2Read() {
   if (!isSensorRegistered(SENSORS::SDFRNO2)) return;
-  no2 = dfrNO2.readGasConcentrationPPM();
+  float rawPpm = dfrNO2.readGasConcentrationPPM();
+  float dfrInternalTemp = dfrNO2.readTempC();
+  float compensationTemp = (temp != 0.0) ? temp : (dfrInternalTemp - toffset);
+  no2 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::NO2);
+  if (pres > 0.0) no2 = dfrGasPressCompensation(no2, pres);
   unitRegister(UNIT::NO2);
   dataReady = true;
   if (temp == 0.0) {
-    temp = dfrNO2.readTempC() - toffset;
+    temp = dfrInternalTemp - toffset;
     tempRegister(false);
   }
 }
 
 void Sensors::DFRobotO3Read() {
   if (!isSensorRegistered(SENSORS::SDFRO3)) return;
-  o3 = dfrO3.readGasConcentrationPPM();
+  float rawPpm = dfrO3.readGasConcentrationPPM();
+  float dfrInternalTemp = dfrO3.readTempC();
+  float compensationTemp = (temp != 0.0) ? temp : (dfrInternalTemp - toffset);
+  o3 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::O3);
+  if (pres > 0.0) o3 = dfrGasPressCompensation(o3, pres);
   unitRegister(UNIT::O3);
   dataReady = true;
   if (temp == 0.0) {
-    temp = dfrO3.readTempC() - toffset;
+    temp = dfrInternalTemp - toffset;
     tempRegister(false);
   }
 }
@@ -2187,6 +2203,85 @@ void Sensors::GCJA5Init() {
   sensorRegister(SENSORS::SGCJA5);
 }
 
+/**
+ * @brief Temperature compensation for DFRobot gas sensors using external temperature.
+ *
+ * Reimplements the DFRobot library formulas (from DFRobot_MultiGasSensor.cpp)
+ * so we can feed the current ambient temperature from an external sensor
+ * (BME280, SHT31, etc.) instead of the stale onboard thermistor value that
+ * the library captures only once at init.
+ *
+ * @param rawPpm  Uncompensated gas concentration from readGasConcentrationPPM()
+ * @param temperature  Ambient temperature in °C (from external sensor)
+ * @param gasType  DFRobot gas type constant (DFRobot_GAS::CO, ::NH3, ::NO2, ::O3)
+ * @return Compensated gas concentration in PPM
+ */
+float Sensors::dfrGasTempCompensation(float rawPpm, float temperature, uint8_t gasType) {
+  float compensated = rawPpm;
+
+  switch (gasType) {
+    case DFRobot_GAS::CO:
+      if (temperature > -20 && temperature <= 20) {
+        compensated = rawPpm / (0.005 * temperature + 0.9);
+      } else if (temperature > 20 && temperature <= 40) {
+        compensated = rawPpm / (0.005 * temperature + 0.9) - (0.3 * temperature - 6);
+      }
+      break;
+
+    case DFRobot_GAS::NH3:
+      if (temperature > -20 && temperature <= 0) {
+        compensated = rawPpm / (0.006 * temperature + 0.95) - (-0.006 * temperature + 0.25);
+      } else if (temperature > 0 && temperature <= 20) {
+        compensated = rawPpm / (0.006 * temperature + 0.95) - (-0.012 * temperature + 0.25);
+      } else if (temperature > 20 && temperature <= 40) {
+        compensated = rawPpm / (0.005 * temperature + 1.08) - (-0.1 * temperature + 2);
+      }
+      break;
+
+    case DFRobot_GAS::NO2:
+      if (temperature > -20 && temperature <= 0) {
+        compensated = rawPpm / (0.005 * temperature + 0.9) - (-0.0025 * temperature + 0.005);
+      } else if (temperature > 0 && temperature <= 20) {
+        compensated = rawPpm / (0.005 * temperature + 0.9) - (0.005 * temperature + 0.005);
+      } else if (temperature > 20 && temperature <= 40) {
+        compensated = rawPpm / (0.005 * temperature + 0.9) - (0.0025 * temperature + 0.1);
+      }
+      break;
+
+    case DFRobot_GAS::O3:
+      if (temperature > -20 && temperature <= 0) {
+        compensated = rawPpm / (0.015 * temperature + 1.1) - 0.05;
+      } else if (temperature > 0 && temperature <= 20) {
+        compensated = rawPpm / 1.1 - (0.01 * temperature);
+      } else if (temperature > 20 && temperature <= 40) {
+        compensated = rawPpm / 1.1 - (-0.005 * temperature + 0.3);
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  return (compensated >= 0) ? compensated : 0.0f;
+}
+
+/**
+ * @brief Pressure compensation for electrochemical gas sensors.
+ *
+ * Corrects for the effect of barometric pressure on the partial pressure of
+ * the target gas.  At higher pressure more molecules reach the electrode,
+ * inflating the apparent concentration.
+ *
+ * @param ppm  Gas concentration after temperature compensation
+ * @param pressure  Current barometric pressure in hPa (from BME280/BMP280/BME680)
+ * @return Pressure-compensated gas concentration in PPM
+ */
+float Sensors::dfrGasPressCompensation(float ppm, float pressure) {
+  static const float STANDARD_PRESSURE_HPA = 1013.25f;
+  if (pressure <= 0.0f) return ppm;
+  return ppm * (STANDARD_PRESSURE_HPA / pressure);
+}
+
 /// DFRobot GAS (CO) sensors init
 void Sensors::DFRobotCOInit() {
   sensorAnnounce(SENSORS::SDFRCO);
@@ -2209,8 +2304,8 @@ void Sensors::DFRobotCOInit() {
   // Mode of obtaining data: the main controller needs to request the sensor for data
   dfrCO.changeAcquireMode(dfrCO.PASSIVITY);
   delay(500);  // Required for PASSIVITY mode to stabilize (see DFRobot example)
-  // Turn on temperature compensation: gas.ON : turn on
-  dfrCO.setTempCompensation(dfrCO.ON);
+  // Disable internal compensation: we apply our own using external T/P sensors
+  dfrCO.setTempCompensation(dfrCO.OFF);
   sensorRegister(SENSORS::SDFRCO);
 }
 
@@ -2225,8 +2320,8 @@ void Sensors::DFRobotNH3Init() {
   // Mode of obtaining data: the main controller needs to request the sensor for data
   dfrNH3.changeAcquireMode(dfrNH3.PASSIVITY);
   delay(500);  // Required for PASSIVITY mode to stabilize (see DFRobot example)
-  // Turn on temperature compensation: gas.ON : turn on
-  dfrNH3.setTempCompensation(dfrNH3.ON);
+  // Disable internal compensation: we apply our own using external T/P sensors
+  dfrNH3.setTempCompensation(dfrNH3.OFF);
   sensorRegister(SENSORS::SDFRNH3);
 }
 
@@ -2241,8 +2336,8 @@ void Sensors::DFRobotNO2Init() {
   // Mode of obtaining data: the main controller needs to request the sensor for data
   dfrNO2.changeAcquireMode(dfrNO2.PASSIVITY);
   delay(500);  // Required for PASSIVITY mode to stabilize (see DFRobot example)
-  // Turn on temperature compensation: gas.ON : turn on
-  dfrNO2.setTempCompensation(dfrNO2.ON);
+  // Disable internal compensation: we apply our own using external T/P sensors
+  dfrNO2.setTempCompensation(dfrNO2.OFF);
   sensorRegister(SENSORS::SDFRNO2);
 }
 
@@ -2257,8 +2352,8 @@ void Sensors::DFRobotO3Init() {
   // Mode of obtaining data: the main controller needs to request the sensor for data
   dfrO3.changeAcquireMode(dfrO3.PASSIVITY);
   delay(500);  // Required for PASSIVITY mode to stabilize (see DFRobot example)
-  // Turn on temperature compensation: gas.ON : turn on
-  dfrO3.setTempCompensation(dfrO3.ON);
+  // Disable internal compensation: we apply our own using external T/P sensors
+  dfrO3.setTempCompensation(dfrO3.OFF);
   sensorRegister(SENSORS::SDFRO3);
 }
 

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -45,37 +45,24 @@
 #define CSL_REVISION 385
 
 /***************************************************************
- * D F R o b o t   G r a v i t y   g a s   ( S E N 0 4 6 5 – S E N 0 4 7 6 / M E M S )
+ * D F R o b o t   G r a v i t y   g a s   s e n s o r s
  ***************************************************************/
 /**
- * DFRobot Gravity gas — two supported setups:
+ * DFRobot Gravity gas sensors — fixed I2C addresses (group 7):
+ *   CO  @ 0x78  (SEN0466)
+ *   O3  @ 0x79  (SEN0472)
+ *   NH3 @ 0x7A  (SEN0469)
+ *   NO2 @ 0x7B  (SEN0471)
  *
- * 1) Default (DFROBOT_MEMS_LEGACY_GROUP7=0): electrochemical wiki — I2C group 6, 0x74–0x77 per DIP.
- *    CO @ 0x74, O3 @ 0x75 (set O3 DIP so it does not share 0x74 with CO).
- *
- * 2) CanAirIO / MEMS group 7 (DFROBOT_MEMS_LEGACY_GROUP7=1): matches
- * canair.io/docs/dfrobot_sensors.html — CO @ 0x78, O3 @ 0x79, NH3 @ 0x7A, NO2 @ 0x7B;
- * DFRobotCOInit() runs changeI2cAddrGroup(7) on 0x74–0x77.
- *
- * Override: -D DFROBOT_CO_I2C_ADDR=0x76 -D DFROBOT_O3_I2C_ADDR=0x77
+ * Override any address via build_flags, e.g.:
+ *   -D DFROBOT_CO_I2C_ADDR=0x74
  */
-#ifndef DFROBOT_MEMS_LEGACY_GROUP7
-#define DFROBOT_MEMS_LEGACY_GROUP7 0
-#endif
 #ifndef DFROBOT_CO_I2C_ADDR
-// #if DFROBOT_MEMS_LEGACY_GROUP7
 #define DFROBOT_CO_I2C_ADDR 0x78
-// #else
-// #define DFROBOT_CO_I2C_ADDR 0x74
 #endif
-// #endif
 #ifndef DFROBOT_O3_I2C_ADDR
-// #if DFROBOT_MEMS_LEGACY_GROUP7
 #define DFROBOT_O3_I2C_ADDR 0x79
-// #else
-// #define DFROBOT_O3_I2C_ADDR 0x75
 #endif
-// #endif
 #ifndef DFROBOT_NH3_I2C_ADDR
 #define DFROBOT_NH3_I2C_ADDR 0x7A
 #endif

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -63,19 +63,19 @@
 #define DFROBOT_MEMS_LEGACY_GROUP7 0
 #endif
 #ifndef DFROBOT_CO_I2C_ADDR
-#if DFROBOT_MEMS_LEGACY_GROUP7
+// #if DFROBOT_MEMS_LEGACY_GROUP7
 #define DFROBOT_CO_I2C_ADDR 0x78
-#else
-#define DFROBOT_CO_I2C_ADDR 0x74
+// #else
+// #define DFROBOT_CO_I2C_ADDR 0x74
 #endif
-#endif
+// #endif
 #ifndef DFROBOT_O3_I2C_ADDR
-#if DFROBOT_MEMS_LEGACY_GROUP7
+// #if DFROBOT_MEMS_LEGACY_GROUP7
 #define DFROBOT_O3_I2C_ADDR 0x79
-#else
-#define DFROBOT_O3_I2C_ADDR 0x75
+// #else
+// #define DFROBOT_O3_I2C_ADDR 0x75
 #endif
-#endif
+// #endif
 #ifndef DFROBOT_NH3_I2C_ADDR
 #define DFROBOT_NH3_I2C_ADDR 0x7A
 #endif

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -630,6 +630,7 @@ class Sensors {
 
   float dfrGasTempCompensation(float rawPpm, float temperature, uint8_t gasType);
   float dfrGasPressCompensation(float ppm, float pressure);
+  bool dfrHasExternalTempSensor() const;
 
   // UART sensors methods:
 

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -628,6 +628,9 @@ class Sensors {
   void DFRobotO3Init();
   void DFRobotO3Read();
 
+  float dfrGasTempCompensation(float rawPpm, float temperature, uint8_t gasType);
+  float dfrGasPressCompensation(float ppm, float pressure);
+
   // UART sensors methods:
 
   bool sensorSerialInit(u_int pms_type, int rx, int tx);


### PR DESCRIPTION

Overhaul of DFRobot Gravity gas sensor handling (CO, NH3, NO2, O3) to improve accuracy across varying environmental conditions.

Temperature & pressure compensation with external sensors
Disabled the DFRobot library's internal temperature compensation (setTempCompensation(OFF)), which reads the onboard thermistor only once at init and never updates it, causing stale compensation when the device is moved between locations.
Reimplemented the compensation formulas in dfrGasTempCompensation() using a fresh temperature reading each cycle — either from an external sensor (BME280, SHT31, BME680, etc.) or the DFRobot's own updated internal thermistor when no external sensor is present.
Added pressure compensation via dfrGasPressCompensation() using barometric pressure from BME280/BMP280/BME680 (Dalton's law correction at 1013.25 hPa reference).
Low-concentration fallback (NO2/O3/CO fix)
The DFRobot compensation formulas contain a baseline offset subtraction that produces negative values for typical ambient NO2 (<50 ppb) and O3 (<100 ppb) concentrations, resulting in readings clamped to 0.
Split each formula into a gain divisor (sensitivity correction) and baseline offset (zero-point correction). When the offset would make the result negative, the function falls back to the gain-only correction instead of returning 0.
External temperature sensor detection
Replaced the unreliable temp != 0.0 sentinel (fails at 0°C) with dfrHasExternalTempSensor(), which checks if specific hardware sensors (BME280, SHT31, etc.) are registered — avoiding a subtle bug where DFRobot's own tempRegister() call would cause all subsequent reads to believe an external sensor was present.
Fixed I2C addresses & cleanup
Removed DFROBOT_MEMS_LEGACY_GROUP7 macro and all conditional changeI2cAddrGroup(7) logic.
Fixed addresses (group 7): CO 0x78, O3 0x79, NH3 0x7A, NO2 0x7B — overridable via build_flags.
Cleaned up platformio.ini, README.md, and error messages.
Other fixes
SCD4x getTemperatureOffset(): always calls startPeriodicMeasurement() even if stopPeriodicMeasurement() fails, preventing the sensor from staying permanently stopped.
Gas sensor log precision: increased from 1 to 2 decimal places for CO, NH3, NO2, O3.
Files changed
File	Changes
src/Sensors.cpp
Compensation functions, Read/Init refactor, SCD4x fix, log precision
src/Sensors.hpp
I2C address macros, new method declarations
platformio.ini
Removed legacy build flags
README.md
Updated DFRobot documentation with address table
Test plan

 Verify CO, NH3, NO2, O3 sensors initialize correctly at fixed I2C addresses

 Confirm NO2 and O3 show non-zero readings at typical ambient concentrations

 Test with external temperature sensor (BME280/SHT31) — verify compensation uses external temp

 Test without external temperature sensor — verify DFRobot internal thermistor is used as fallback

 Verify SCD4x CO2 readings continue after a stopPeriodicMeasurement() error

 Check serial log shows 2 decimal places for gas sensors, 1 for others