### PR TITLE
noise sensor beter auto detection

### DIFF
--- a/library.json
+++ b/library.json
@@ -93,8 +93,6 @@
     {"name":"Sensirion I2C SEN5X","owner":"sensirion","version":"0.3.0"},
     {"name":"Sensirion I2C SGP41","owner":"sensirion","version":"1.0.0"},
     {"name":"DFRobot_MultiGasSensor","version":"https://github.com/DFRobot/DFRobot_MultiGasSensor.git"},
-    {"name":"NoiseSensor", "owner":"roberbike", "version":"^1.1.0"},
-    {"name":"NoiseSensorI2CSlave", "version":"https://github.com/roberbike/NoiseSensorI2CSlave.git"},
     {"name":"AHTxx", "version":"https://github.com/enjoyneering/AHTxx.git#eb21571"},
     {"name":"DHT_nonblocking", "version":"https://github.com/hpsaturn/DHT_nonblocking.git#ec6e5b9"},
     {"name":"SN-GCJA5", "version":"https://github.com/paulvha/SN-GCJA5.git#f261968"},

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1373,6 +1373,10 @@ bool Sensors::noiseSensorAutoDetect() {
       if (devmode) Serial.printf("-->[SLIB] Wrong sensor type at: 0x%02X (0x%02X)\r\n", addr, identity.sensorType);
       continue;
     }
+    if (identity.i2cAddress != addr) {
+      if (devmode) Serial.printf("-->[SLIB] Addr mismatch at: 0x%02X (reported 0x%02X)\r\n", addr, identity.i2cAddress);
+      continue;
+    }
 
     noiseSensorEnabled = true;
     noiseSensorAddress = addr;

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1370,11 +1370,15 @@ bool Sensors::noiseSensorAutoDetect() {
       continue;
     }
     if (identity.sensorType != NOISE_SENSOR_TYPE_ID) {
-      if (devmode) Serial.printf("-->[SLIB] Wrong sensor type at: 0x%02X (0x%02X)\r\n", addr, identity.sensorType);
+      if (devmode)
+        Serial.printf("-->[SLIB] Wrong sensor type at: 0x%02X (0x%02X)\r\n", addr,
+                      identity.sensorType);
       continue;
     }
     if (identity.i2cAddress != addr) {
-      if (devmode) Serial.printf("-->[SLIB] Addr mismatch at: 0x%02X (reported 0x%02X)\r\n", addr, identity.i2cAddress);
+      if (devmode)
+        Serial.printf("-->[SLIB] Addr mismatch at: 0x%02X (reported 0x%02X)\r\n", addr,
+                      identity.i2cAddress);
       continue;
     }
 

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1333,9 +1333,8 @@ void Sensors::DFRobotO3Read() {
 #ifdef CSL_NOISE_SENSOR_SUPPORTED
 bool Sensors::noiseSensorAutoDetect() {
   if (noiseSensorEnabled) return true;
-  if (noiseScanDone && (millis() - noiseLastScanMs < noiseScanRetryMs)) return false;
+  if (noiseScanDone) return false;
   noiseScanDone = true;
-  noiseLastScanMs = millis();
 
   noiseSensorInitWire();
   if (noiseWire == nullptr) {
@@ -1343,22 +1342,17 @@ bool Sensors::noiseSensorAutoDetect() {
     return false;
   }
 
-  for (uint8_t addr = MIN_I2C_ADDRESS; addr <= MAX_I2C_ADDRESS; addr++) {
-    if (devmode && (addr == MIN_I2C_ADDRESS || (addr % 16 == 0)))
-      Serial.printf("-->[SLIB] Scanning I2C addr: 0x%02X\r\n", addr);
-    bool present = noiseSensorDevicePresent(*noiseWire, addr);
-    if (devmode && addr == MIN_I2C_ADDRESS)
-      Serial.printf("-->[SLIB] Probe 0x%02X: %s\r\n", addr, present ? "ACK" : "NACK");
-    if (!present) continue;
+  for (uint8_t addr = NOISE_MIN_SCAN_ADDR; addr <= NOISE_MAX_SCAN_ADDR; addr++) {
+    if (!noiseSensorDevicePresent(*noiseWire, addr)) continue;
     if (devmode) Serial.printf("-->[SLIB] Found device at: 0x%02X, reading identity...\r\n", addr);
 
-    uint8_t status = 0xFF;
-    if (!noiseSensorReadStatus(*noiseWire, addr, status)) {
-      if (devmode) Serial.printf("-->[SLIB] Failed to read status at: 0x%02X\r\n", addr);
+    SensorIdentity identity;
+    if (!noiseSensorReadIdentity(*noiseWire, addr, identity)) {
+      if (devmode) Serial.printf("-->[SLIB] No identity response at: 0x%02X\r\n", addr);
       continue;
     }
-    if (status > 0x07) {
-      if (devmode) Serial.printf("-->[SLIB] Wrong status at: 0x%02X (0x%02X)\r\n", addr, status);
+    if (identity.sensorType != NOISE_SENSOR_TYPE_ID) {
+      if (devmode) Serial.printf("-->[SLIB] Wrong sensor type at: 0x%02X (0x%02X)\r\n", addr, identity.sensorType);
       continue;
     }
 
@@ -1375,6 +1369,7 @@ bool Sensors::noiseSensorAutoDetect() {
 }
 
 void Sensors::noiseSensorService() {
+  // Detection is done once at boot; noiseScanDone prevents any retry.
   if (noiseSensorEnabled || noiseScanDone) return;
   noiseSensorAutoDetect();
 }
@@ -1427,22 +1422,17 @@ void Sensors::noiseSensorCollect() {
   unitRegister(UNIT::NOISELDEN);
 }
 
-bool Sensors::noiseSensorReadStatus(TwoWire &wire, uint8_t address, uint8_t &status) {
-  int retries = 3;
-  while (retries-- > 0) {
-    wire.beginTransmission(address);
-    wire.write(CMD_GET_STATUS);
-    if (wire.endTransmission(true) == 0) {
-      delay(10);
-      uint8_t got = wire.requestFrom(address, (uint8_t)1);
-      if (got == 1) {
-        status = wire.read();
-        return true;
-      }
-    }
-    delay(100);
-  }
-  return false;
+bool Sensors::noiseSensorReadIdentity(TwoWire &wire, uint8_t address, SensorIdentity &identity) {
+  wire.beginTransmission(address);
+  wire.write(CMD_IDENTIFY);
+  if (wire.endTransmission(true) != 0) return false;
+  delay(5);
+  uint8_t got = wire.requestFrom(address, (uint8_t)sizeof(SensorIdentity));
+  if (got != sizeof(SensorIdentity)) return false;
+  uint8_t buffer[sizeof(SensorIdentity)];
+  wire.readBytes(buffer, sizeof(SensorIdentity));
+  memcpy(&identity, buffer, sizeof(SensorIdentity));
+  return true;
 }
 
 bool Sensors::noiseSensorReadData(TwoWire &wire, uint8_t address, SensorData &out) {

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -565,10 +565,10 @@ class Sensors {
   float noiseLnValue = 0.0;
   float noiseLdenValue = 0.0;
   bool noiseScanDone = false;
-  uint32_t noiseLastScanMs = 0;
-  uint32_t noiseScanRetryMs = 5000;
   uint32_t noiseLastTimeSyncMs = 0;
+  uint32_t noiseLastSyncAttemptMs = 0;
   uint32_t noiseTimeSyncIntervalMs = 86400000;
+  static constexpr uint32_t NOISE_SYNC_RETRY_MS = 30000;
   bool noiseTimeSyncEnabled = true;
 
   void am2320Init();
@@ -689,7 +689,7 @@ class Sensors {
   bool noiseSensorAutoDetect();
   void noiseSensorService();
   void noiseSensorCollect();
-  bool noiseSensorReadStatus(TwoWire &wire, uint8_t address, uint8_t &status);
+  bool noiseSensorReadIdentity(TwoWire &wire, uint8_t address, SensorIdentity &identity);
   bool noiseSensorReadData(TwoWire &wire, uint8_t address, SensorData &out);
   bool noiseSensorDevicePresent(TwoWire &wire, uint8_t address);
   void noiseSensorInitWire();

--- a/src/drivers/NoiseSlave.h
+++ b/src/drivers/NoiseSlave.h
@@ -51,8 +51,8 @@ struct SensorIdentity {
 
 // I2C Addresses
 static constexpr uint8_t DEFAULT_NOISE_ADDR = 0x08;
-static constexpr uint8_t MIN_I2C_ADDRESS = 0x08;
-static constexpr uint8_t MAX_I2C_ADDRESS = 0x77;
+static constexpr uint8_t NOISE_MIN_SCAN_ADDR = 0x08;
+static constexpr uint8_t NOISE_MAX_SCAN_ADDR = 0x0F;
 
 static constexpr uint8_t SENSOR_TYPE_NOISE = 0x01;
 static constexpr uint8_t NOISE_SENSOR_TYPE_ID = SENSOR_TYPE_NOISE;


### PR DESCRIPTION
fix: noise sensor detection rewrite for T7S3 boot performance
- Replace full I2C bus scan (0x08-0x77, 112 addrs) with targeted scan
  of NOISE_MIN_SCAN_ADDR..NOISE_MAX_SCAN_ADDR (0x08-0x0F, 8 addrs)
- Replace noiseSensorReadStatus (CMD_GET_STATUS + ambiguous 1-byte reply
  with 3x100ms retries) with noiseSensorReadIdentity (CMD_IDENTIFY +
  SensorIdentity struct verification via sensorType==0x01), ensuring the
  sensor is correctly identified and not confused with OLED or other I2C
  devices
- Remove periodic re-scan (noiseScanRetryMs=5000): detection is now a
  one-shot boot operation; noiseScanDone permanently prevents retries
- Remove noiseLastScanMs and noiseScanRetryMs state vars; add
  noiseLastSyncAttemptMs and NOISE_SYNC_RETRY_MS (30s) to rate-limit
  time sync retries before first successful sync

fix(noise): add i2cAddress self-report check to prevent false detection
After adding address validation in noiseSensorAutoDetect(), a device
must pass two independent checks to be accepted as a noise sensor:
  1. identity.sensorType == NOISE_SENSOR_TYPE_ID (0x01)
  2. identity.i2cAddress == scanned address

Any I2C device that is not the noise sensor (OLED, EEPROM, etc.) will
fail check 2 because it will not self-report its I2C address in the
SensorIdentity struct, eliminating false positives on shared buses.

fix(library.json): remove NoiseSensor and NoiseSensorI2CSlave dependencies
NoiseSensor and NoiseSensorI2CSlave are slave-side libraries not needed
by the canairio firmware (which acts as I2C master). Their inclusion
caused build failures on classic ESP32 boards (espressif32 @ 4.4.0)
because NoiseSensorI2CSlave uses Wire.setBufferSize() which was
introduced in Arduino ESP32 2.x (espressif32 @ 6.x).

The noise sensor protocol is already self-contained in
src/drivers/NoiseSlave.h -- no external dependency required.

