### PR TITLE
Dfrobot compensations

### DIFF
--- a/examples/DfRobot_Multigas/i2c_change/README.md
+++ b/examples/DfRobot_Multigas/i2c_change/README.md
@@ -1,0 +1,283 @@
+# DFRobot MultiGas Sensor - Auto-Configuration
+
+## Descripción General
+
+Este sketch permite detectar automáticamente sensores de gas DFRobot conectados a tu microcontrolador y configura todos con los mismos parámetros:
+
+- ✅ **Detección automática** del tipo de sensor (NH3, CO, NO2, O3)
+- ✅ **Cambio de dirección I2C** al grupo 7 (0x78-0x7B)
+- ✅ **Activación de compensación de temperatura**
+- ✅ **Activación del modo pasivo** (lectura bajo demanda)
+
+No necesitas hardcodear direcciones ni conocer los tipos de sensores de antemano.
+
+---
+
+## Requisitos de Hardware
+
+### Microcontrolador Soportado
+- ESP32, ESP8266, Arduino, o cualquier board con soporte I2C
+
+### Sensores DFRobot Multigas
+Cualquier combinación de estos sensores (hasta 4):
+- **SEN0466** - Gas NH3
+- **SEN0467** - Gas CO
+- **SEN0468** - Gas NO2
+- **SEN0469** - Gas O3
+
+### Conexiones I2C
+```
+Sensor Pin 1 (GND) → GND del microcontrolador
+Sensor Pin 2 (VCC) → 3.3V o 5V
+Sensor Pin 3 (SDA) → Pin SDA del microcontrolador (GPIO 21 en ESP32)
+Sensor Pin 4 (SCL) → Pin SCL del microcontrolador (GPIO 22 en ESP32)
+```
+
+> **Nota:** Los sensores deben estar en modo I2C (DIP switch SEL = 0)
+
+---
+
+## Cómo Funciona
+
+### Pasos que el Sketch Realiza
+
+#### 1️⃣ **Inicialización** (setup)
+```
+Serial begins → Scanning for sensors...
+```
+
+#### 2️⃣ **Escaneo de Sensores**
+- Explora las direcciones del **grupo 6 por defecto** (0x74, 0x75, 0x76, 0x77)
+- Identifica cada sensor encontrado con su tipo de gas
+- Crea un registro interno para cada sensor
+
+#### 3️⃣ **Configuración de Cada Sensor**
+Para cada sensor detectado:
+1. Cambia la dirección I2C al **grupo 7**
+2. Activa **compensación de temperatura**
+3. Activa **modo pasivo** (necesarias peticiones para datos)
+
+#### 4️⃣ **Lectura Continua** (loop)
+- Solicita datos a cada sensor cada 2 segundos
+- Muestra concentración en PPM o %vol (según el gas)
+
+---
+
+## Pasos para Usar
+
+### Paso 1: Preparar el Hardware
+1. Conecta los sensores DFRobot al microcontrolador por I2C
+2. Verifica que todos los sensores estén en modo I2C (DIP: SEL = 0)
+3. Asegúrate de que cada sensor está en el **grupo 6 por defecto** (ver tabla de direcciones)
+
+### Paso 2: Cargar el Sketch
+1. Abre PlatformIO o Arduino IDE
+2. Abre el archivo `src/main.cpp` en esta carpeta
+3. Conecta tu microcontrolador por USB
+4. Selecciona la placa y puerto correcto
+5. Compila y carga el sketch: `Upload` o `Ctrl+Alt+U`
+
+### Paso 3: Monitorear la Consola Serial
+1. Abre el Monitor Serial (`Ctrl+J` en PlatformIO)
+2. Configura la velocidad en **115200 baud**
+3. Presiona el botón RESET del microcontrolador (o desconecta/reconecta USB)
+
+### Paso 4: Verificar la Detección
+Deberías ver en consola:
+```
+========================================
+DFRobot MultiGas Sensor Auto-Configure
+========================================
+
+Scanning for sensors...
+
+Detected sensor at 0x74: NH3
+Detected sensor at 0x75: CO
+Detected sensor at 0x76: NO2
+Detected sensor at 0x77: O3
+
+Found 4 sensor(s)
+```
+
+### Paso 5: Verificar la Configuración
+El sketch continuará mostrando:
+```
+========================================
+Configuring sensors...
+========================================
+
+Configuring NH3 sensor at 0x74
+  - I2C address group changed to 7
+  - Temperature compensation enabled
+  - Passive mode enabled
+  - Configuration complete for NH3 sensor
+
+[Similar para los otros sensores...]
+
+========================================
+Configuration complete!
+========================================
+```
+
+### Paso 6: Lectura de Datos
+Una vez completada la configuración, verás lecturas periódicas:
+```
+NH3 (0x74): 45.23 PPM
+CO (0x75): 12.56 PPM
+NO2 (0x76): 8.90 PPM
+O3 (0x77): 5.34 PPM
+```
+
+---
+
+## Salida Esperada en la Consola
+
+### Caso de Éxito ✅
+```
+========================================
+DFRobot MultiGas Sensor Auto-Configure
+========================================
+
+Scanning for sensors...
+
+Detected sensor at 0x74: NH3
+Detected sensor at 0x75: CO
+
+Found 2 sensor(s)
+
+========================================
+Configuring sensors...
+========================================
+
+Configuring NH3 sensor at 0x74
+  - I2C address group changed to 7
+  - Temperature compensation enabled
+  - Passive mode enabled
+  - Configuration complete for NH3 sensor
+
+Configuring CO sensor at 0x75
+  - I2C address group changed to 7
+  - Temperature compensation enabled
+  - Passive mode enabled
+  - Configuration complete for CO sensor
+
+========================================
+Configuration complete!
+========================================
+
+NH3 (0x74): 23.45 PPM
+CO (0x75): 5.67 PPM
+
+NH3 (0x74): 23.50 PPM
+CO (0x75): 5.68 PPM
+```
+
+### Caso de Error ❌
+```
+ERROR: No sensors detected!
+Please check I2C connections and sensor power.
+```
+
+---
+
+## Solución de Problemas
+
+### "No sensors detected!"
+
+**Causas posibles:**
+1. ❌ Sensores no conectados correctamente
+2. ❌ Sensores sin alimentación
+3. ❌ Sensores en modo UART (DIP: SEL = 1)
+4. ❌ Cables I2C defectuosos
+5. ❌ Pines SDA/SCL incorrectos en el código
+
+**Soluciones:**
+- Verifica las conexiones físicas
+- Asegúrate de que los sensores tengan alimentación (verde LED encendido)
+- Cambia el DIP switch SEL a 0 (modo I2C)
+- Prueba con un cable USB diferente
+- Consulta el datasheet de tu microcontrolador para los pines I2C correctos
+
+### "IIC address change attempt failed, retrying..."
+
+**Causas posibles:**
+1. ❌ Sensor recién conectado (necesita tiempo de inicialización)
+2. ❌ Comunicación I2C inestable
+3. ❌ Sensor con dirección bloqueada
+
+**Soluciones:**
+- Espera 10 segundos después de conectar los sensores antes de cargar el sketch
+- Reduce la velocidad I2C si es posible (por defecto 100kHz)
+- Intenta reinicar el sketch (botón RESET)
+- Si falla 5 veces consecutivas, revisa el sensor físicamente
+
+---
+
+## Notas Técnicas
+
+### Tabla de Direcciones I2C por Grupo
+
+| Grupo | A0=0, A1=0 | A0=1, A1=0 | A0=0, A1=1 | A0=1, A1=1 |
+|-------|----------|----------|----------|----------|
+| 6 (Default) | 0x74 | 0x76 | 0x75 | 0x77 |
+| 7 (Este sketch) | 0x78 | 0x7A | 0x79 | 0x7B |
+
+### Parámetros Configurados
+
+| Parámetro | Valor |
+|-----------|-------|
+| Grupo I2C | 7 |
+| Compensación de Temperatura | ON |
+| Modo de Adquisición | PASSIVITY (bajo demanda) |
+| Intervalo de Lectura | 2 segundos |
+
+### Modificar los Parámetros
+
+Si necesitas cambiar algo, edita estas líneas en `src/main.cpp`:
+
+```cpp
+// Cambiar grupo I2C (línea 72)
+while (!info.sensor->changeI2cAddrGroup(7) && attempts < MAX_ATTEMPTS) {
+  // Cambia el 7 al grupo deseado (1-8)
+}
+
+// Cambiar intervalo de lectura (línea 164)
+delay(2000);  // Cambia 2000 por el intervalo en milisegundos
+```
+
+---
+
+## Librería Requerida
+
+Este sketch requiere la librería oficial de DFRobot:
+```
+DFRobot_MultiGasSensor
+```
+
+Si usas PlatformIO, se instalará automáticamente desde `platformio.ini`.
+
+---
+
+## Preguntas Frecuentes
+
+**P: ¿Puedo usar sensores de diferentes grupos a la vez?**
+R: No, este script cambia todos al grupo 7. Si necesitas grupos diferentes, modifica la función `configureSensor()`.
+
+**P: ¿Cuántos sensores puedo conectar?**
+R: Hasta 4 sensores diferentes (uno de cada tipo de gas) en las 4 direcciones del grupo 7.
+
+**P: ¿El script daña los sensores?**
+R: No, solo cambia parámetros de configuración almacenados en EEPROM del sensor. Son reversibles.
+
+**P: ¿Necesito volver a subir el sketch cada vez?**
+R: No, la configuración se guarda en el sensor. Solo necesitas hacerlo una vez.
+
+---
+
+## Versión y Autor
+
+- **Versión:** 2.0
+- **Fecha:** 2026
+- **Base:** DFRobot MultiGasSensor Library
+- **Librería Original:** https://github.com/DFRobot/DFRobot_MultiGasSensor
+

--- a/examples/DfRobot_Multigas/i2c_change/main.cpp
+++ b/examples/DfRobot_Multigas/i2c_change/main.cpp
@@ -1,146 +1,165 @@
 /*!
- * @file  readGasConcentration.ino
- * @brief Obtain gas concentration corresponding to the current environment, output as concentration
- * value
- * @n Experimental mode: connect sensor communication pin to the main controller and burn
- * @n Communication mode select, DIP switch SEL: 0: I2C, 1: UART
- * @n Group serial number         Address in the group
- * @n A0 A1 DIP level 00    01    10    11
- * @n 1            0x60  0x61  0x62  0x63
- * @n 2            0x64  0x65  0x66  0x67
- * @n 3            0x68  0x69  0x6A  0x6B
- * @n 4            0x6C  0x6D  0x6E  0x6F
- * @n 5            0x70  0x71  0x72  0x73
- * @n 6 (Default address group) 0x74  0x75  0x76  0x77 (Default address)
- * @n 7            0x78  0x79  0x7A  0x7B
- * @n 8            0x7C  0x7D  0x7E  0x7F
- * @n i2c address select, default to 0x77, A1 and A0 are grouped into 4 I2C addresses.
- * @n             | A0 | A1 |
- * @n             | 0  | 0  |    0x74
- * @n             | 0  | 1  |    0x75
- * @n             | 1  | 0  |    0x76
- * @n             | 1  | 1  |    0x77   default i2c address
- * @n Experimental phenomenon: view the gas concentration corresponding to the current environment
- * through serial port printing
+ * @file  i2c_change_auto_detect.ino
+ * @brief Auto-detect DFRobot multigas sensors and configure them:
+ *        - Detect sensor type (NH3, CO, NO2, O3)
+ *        - Change I2C address to group 7
+ *        - Enable temperature compensation
+ *        - Set to passive mode
+ * @n I2C Address groups (group 7):
+ * @n A0 A1 => 0x78, 0x79, 0x7A, 0x7B
  * @copyright   Copyright (c) 2010 DFRobot Co.Ltd (http://www.dfrobot.com)
  * @license     The MIT License (MIT)
- * @author      PengKaixing(kaixing.peng@dfrobot.com)
- * @version     V1.0
- * @date        2021-03-28
- * @url         https://github.com/DFRobot/DFRobot_MultiGasSensor
+ * @version     V2.0
  */
 #include <Arduino.h>
 
 #include "DFRobot_MultiGasSensor.h"
 
-// Turn on by default, using I2C communication at the time, switch to serial port communication
-// after turning off #define I2C_COMMUNICATION
+#define MAX_SENSORS 4
+#define GROUP_7_BASE_ADDR 0x78
 
-// #ifdef  I2C_COMMUNICATION
-// #define I2C_ADDRESS    0x77
-DFRobot_GAS_I2C nh3(&Wire, 0x7A);
-DFRobot_GAS_I2C co(&Wire, 0x78);
-DFRobot_GAS_I2C no2(&Wire, 0x7B);
+typedef struct {
+  uint8_t addr;
+  DFRobot_GAS_I2C* sensor;
+  String gasType;
+  bool initialized;
+} SensorInfo;
+
+SensorInfo sensors[MAX_SENSORS];
+int sensorCount = 0;
+
+bool initSensorAtAddress(uint8_t address) {
+  DFRobot_GAS_I2C temp(&Wire, address);
+
+  if (!temp.begin()) {
+    return false;
+  }
+
+  String gasType = temp.queryGasType();
+
+  if (gasType == "" || gasType == "None") {
+    return false;
+  }
+
+  DFRobot_GAS_I2C* newSensor = new DFRobot_GAS_I2C(&Wire, address);
+  newSensor->begin();
+
+  sensors[sensorCount].addr = address;
+  sensors[sensorCount].sensor = newSensor;
+  sensors[sensorCount].gasType = gasType;
+  sensors[sensorCount].initialized = false;
+
+  Serial.print("Detected sensor at 0x");
+  Serial.print(address, HEX);
+  Serial.print(": ");
+  Serial.println(gasType);
+
+  sensorCount++;
+  return true;
+}
+
+void configureSensor(SensorInfo& info) {
+  if (!info.sensor || info.initialized) return;
+
+  int attempts = 0;
+  const int MAX_ATTEMPTS = 5;
+
+  Serial.print("\nConfiguring ");
+  Serial.print(info.gasType);
+  Serial.print(" sensor at 0x");
+  Serial.println(info.addr, HEX);
+
+  while (!info.sensor->changeI2cAddrGroup(7) && attempts < MAX_ATTEMPTS) {
+    Serial.println("  - I2C address change attempt failed, retrying...");
+    delay(500);
+    attempts++;
+  }
+
+  if (attempts >= MAX_ATTEMPTS) {
+    Serial.println("  - ERROR: Failed to change I2C address!");
+    return;
+  }
+
+  Serial.println("  - I2C address group changed to 7");
+  delay(1000);
+
+  // Enable temperature compensation
+  info.sensor->setTempCompensation(info.sensor->ON);
+  Serial.println("  - Temperature compensation enabled");
+  delay(500);
+
+  // Set to passive mode (request data on demand)
+  info.sensor->changeAcquireMode(info.sensor->PASSIVITY);
+  Serial.println("  - Passive mode enabled");
+  delay(500);
+
+  info.initialized = true;
+  Serial.print("  - Configuration complete for ");
+  Serial.print(info.gasType);
+  Serial.println(" sensor");
+}
 
 void setup() {
-  // Serial port init for viewing printing output
   Serial.begin(115200);
+  delay(1000);
 
-  // Change i2c address group
-  while (gas.changeI2cAddrGroup(7) == 0) {
-    Serial.println("IIC addr change fail!");
-    delay(1000);
+  Serial.println("\n========================================");
+  Serial.println("DFRobot MultiGas Sensor Auto-Configure");
+  Serial.println("========================================");
+  Serial.println("\nScanning for sensors...\n");
+
+  // Scan default group 6 addresses (0x74-0x77) for sensors
+  uint8_t defaultAddresses[] = {0x74, 0x75, 0x76, 0x77};
+
+  for (uint8_t addr : defaultAddresses) {
+    if (initSensorAtAddress(addr)) {
+      if (sensorCount >= MAX_SENSORS) break;
+    }
   }
-  Serial.println("IIC addr change success!");
-}
 
-// Sensor init, used to init serial port or I2C, depending on the communication mode currently used
-while (!nh3.begin()) {
-  Serial.println("No Devices NH3 !");
-  delay(1000);
-}
-// Mode of obtaining data: the main controller needs to request the sensor for data
-nh3.changeAcquireMode(nh3.PASSIVITY);
-delay(1000);
+  if (sensorCount == 0) {
+    Serial.println("ERROR: No sensors detected!");
+    Serial.println("Please check I2C connections and sensor power.");
+    while (1) {
+      delay(1000);
+    }
+  }
 
-nh3.setTempCompensation(nh3.ON);
+  Serial.print("\nFound ");
+  Serial.print(sensorCount);
+  Serial.println(" sensor(s)");
 
-Serial.println("The device nh3  0x7A is connected successfully!");
+  // Configure all detected sensors
+  Serial.println("\n========================================");
+  Serial.println("Configuring sensors...");
+  Serial.println("========================================");
 
-while (!co.begin()) {
-  Serial.println("No Devices CO !");
-  delay(1000);
-}
+  for (int i = 0; i < sensorCount; i++) {
+    configureSensor(sensors[i]);
+  }
 
-co.changeAcquireMode(co.PASSIVITY);
-delay(1000);
-
-co.setTempCompensation(co.ON);
-
-Serial.println("The device CO  0x78 is connected successfully!");
-
-while (!no2.begin()) {
-  Serial.println("No Devices NO2 !");
-  delay(1000);
-}
-
-no2.changeAcquireMode(no2.PASSIVITY);
-delay(1000);
-
-no2.setTempCompensation(no2.ON);
-
-Serial.println("The device CO  0x7B is connected successfully!");
+  Serial.println("\n========================================");
+  Serial.println("Configuration complete!");
+  Serial.println("========================================\n");
 }
 
 void loop() {
-  String gastypeNH3 = nh3.queryGasType();
-  /**
-   *Fill in the parameter readGasConcentration() with the type of gas to be obtained and print
-   *The current gas concentration
-   *Print with 1s delay each time
-   */
-  Serial.print("Ambient ");
-  Serial.print(gastypeNH3);
-  Serial.print(" concentration is: ");
-  Serial.print(nh3.readGasConcentrationPPM());
-  if (gastypeNH3 == "O2")
-    Serial.println(" %vol");
-  else
-    Serial.println(" PPM");
-  Serial.println();
-  delay(1000);
+  for (int i = 0; i < sensorCount; i++) {
+    if (sensors[i].initialized) {
+      Serial.print(sensors[i].gasType);
+      Serial.print(" (0x");
+      Serial.print(sensors[i].addr, HEX);
+      Serial.print("): ");
+      Serial.print(sensors[i].sensor->readGasConcentrationPPM());
 
-  String gastypeCO = co.queryGasType();
-  /**
-   *Fill in the parameter readGasConcentration() with the type of gas to be obtained and print
-   *The current gas concentration
-   *Print with 1s delay each time
-   */
-  Serial.print("Ambient ");
-  Serial.print(gastypeCO);
-  Serial.print(" concentration is: ");
-  Serial.print(co.readGasConcentrationPPM());
-  if (gastypeCO == "O2")
-    Serial.println(" %vol");
-  else
-    Serial.println(" PPM");
-  Serial.println();
-  delay(1000);
+      if (sensors[i].gasType == "O2") {
+        Serial.println(" %vol");
+      } else {
+        Serial.println(" PPM");
+      }
+    }
+  }
 
-  String gastypeNO2 = no2.queryGasType();
-  /**
-   *Fill in the parameter readGasConcentration() with the type of gas to be obtained and print
-   *The current gas concentration
-   *Print with 1s delay each time
-   */
-  Serial.print("Ambient ");
-  Serial.print(gastypeNO2);
-  Serial.print(" concentration is: ");
-  Serial.print(no2.readGasConcentrationPPM());
-  if (gastypeNO2 == "O2")
-    Serial.println(" %vol");
-  else
-    Serial.println(" PPM");
   Serial.println();
-  delay(1000);
+  delay(2000);
 }

--- a/examples/DfRobot_Multigas/i2c_change/platformio.ini
+++ b/examples/DfRobot_Multigas/i2c_change/platformio.ini
@@ -16,3 +16,28 @@ monitor_filters = time
 framework = arduino
 lib_deps = 
     https://github.com/DFRobot/DFRobot_MultiGasSensor.git
+
+
+[env:ESP32C3LOLIN]
+platform = espressif32 @ 6.9.0
+board = lolin_c3_mini
+monitor_speed = 115200
+monitor_filters = time
+framework = arduino
+lib_deps = 
+    https://github.com/DFRobot/DFRobot_MultiGasSensor.git
+build_flags =
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D ARDUINO_USB_MODE=1
+
+[env:XIAOS3]
+platform = espressif32 @ 6.9.0
+board = seeed_xiao_esp32s3
+monitor_speed = 115200
+monitor_filters = time
+framework = arduino
+lib_deps = 
+    https://github.com/DFRobot/DFRobot_MultiGasSensor.git
+build_flags =
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D ARDUINO_USB_MODE=1

--- a/examples/DfRobot_Multigas/i2c_change/src/main.cpp
+++ b/examples/DfRobot_Multigas/i2c_change/src/main.cpp
@@ -1,176 +1,165 @@
 /*!
- * @file  readGasConcentration.ino
- * @brief Obtain gas concentration corresponding to the current environment, output as concentration
- * value
- * @n Experimental mode: connect sensor communication pin to the main controller and burn
- * @n Communication mode select, DIP switch SEL: 0: I2C, 1: UART
- * @n Group serial number         Address in the group
- * @n A0 A1 DIP level 00    01    10    11
- * @n 1            0x60  0x61  0x62  0x63
- * @n 2            0x64  0x65  0x66  0x67
- * @n 3            0x68  0x69  0x6A  0x6B
- * @n 4            0x6C  0x6D  0x6E  0x6F
- * @n 5            0x70  0x71  0x72  0x73
- * @n 6 (Default address group) 0x74  0x75  0x76  0x77 (Default address)
- * @n 7            0x78  0x79  0x7A  0x7B
- * @n 8            0x7C  0x7D  0x7E  0x7F
- * @n i2c address select, default to 0x77, A1 and A0 are grouped into 4 I2C addresses.
- * @n             | A0 | A1 |
- * @n             | 0  | 0  |    0x74
- * @n             | 0  | 1  |    0x75
- * @n             | 1  | 0  |    0x76
- * @n             | 1  | 1  |    0x77   default i2c address
- * @n Experimental phenomenon: view the gas concentration corresponding to the current environment
- * through serial port printing
+ * @file  i2c_change_auto_detect.ino
+ * @brief Auto-detect DFRobot multigas sensors and configure them:
+ *        - Detect sensor type (NH3, CO, NO2, O3)
+ *        - Change I2C address to group 7
+ *        - Enable temperature compensation
+ *        - Set to passive mode
+ * @n I2C Address groups (group 7):
+ * @n A0 A1 => 0x78, 0x79, 0x7A, 0x7B
  * @copyright   Copyright (c) 2010 DFRobot Co.Ltd (http://www.dfrobot.com)
  * @license     The MIT License (MIT)
- * @author      PengKaixing(kaixing.peng@dfrobot.com)
- * @version     V1.0
- * @date        2021-03-28
- * @url         https://github.com/DFRobot/DFRobot_MultiGasSensor
+ * @version     V2.0
  */
 #include <Arduino.h>
 
 #include "DFRobot_MultiGasSensor.h"
 
-// Turn on by default, using I2C communication at the time, switch to serial port communication
-// after turning off #define I2C_COMMUNICATION
+#define MAX_SENSORS 4
+#define GROUP_7_BASE_ADDR 0x78
 
-// #ifdef  I2C_COMMUNICATION
-// #define I2C_ADDRESS    0x77
-DFRobot_GAS_I2C nh3(&Wire, 0x7A);
-DFRobot_GAS_I2C co(&Wire, 0x78);
-DFRobot_GAS_I2C no2(&Wire, 0x7B);
-DFRobot_GAS_I2C o3(&Wire, 0x79);
+typedef struct {
+  uint8_t addr;
+  DFRobot_GAS_I2C* sensor;
+  String gasType;
+  bool initialized;
+} SensorInfo;
+
+SensorInfo sensors[MAX_SENSORS];
+int sensorCount = 0;
+
+bool initSensorAtAddress(uint8_t address) {
+  DFRobot_GAS_I2C temp(&Wire, address);
+
+  if (!temp.begin()) {
+    return false;
+  }
+
+  String gasType = temp.queryGasType();
+
+  if (gasType == "" || gasType == "None") {
+    return false;
+  }
+
+  DFRobot_GAS_I2C* newSensor = new DFRobot_GAS_I2C(&Wire, address);
+  newSensor->begin();
+
+  sensors[sensorCount].addr = address;
+  sensors[sensorCount].sensor = newSensor;
+  sensors[sensorCount].gasType = gasType;
+  sensors[sensorCount].initialized = false;
+
+  Serial.print("Detected sensor at 0x");
+  Serial.print(address, HEX);
+  Serial.print(": ");
+  Serial.println(gasType);
+
+  sensorCount++;
+  return true;
+}
+
+void configureSensor(SensorInfo& info) {
+  if (!info.sensor || info.initialized) return;
+
+  int attempts = 0;
+  const int MAX_ATTEMPTS = 5;
+
+  Serial.print("\nConfiguring ");
+  Serial.print(info.gasType);
+  Serial.print(" sensor at 0x");
+  Serial.println(info.addr, HEX);
+
+  while (!info.sensor->changeI2cAddrGroup(7) && attempts < MAX_ATTEMPTS) {
+    Serial.println("  - I2C address change attempt failed, retrying...");
+    delay(500);
+    attempts++;
+  }
+
+  if (attempts >= MAX_ATTEMPTS) {
+    Serial.println("  - ERROR: Failed to change I2C address!");
+    return;
+  }
+
+  Serial.println("  - I2C address group changed to 7");
+  delay(1000);
+
+  // Enable temperature compensation
+  info.sensor->setTempCompensation(info.sensor->ON);
+  Serial.println("  - Temperature compensation enabled");
+  delay(500);
+
+  // Set to passive mode (request data on demand)
+  info.sensor->changeAcquireMode(info.sensor->PASSIVITY);
+  Serial.println("  - Passive mode enabled");
+  delay(500);
+
+  info.initialized = true;
+  Serial.print("  - Configuration complete for ");
+  Serial.print(info.gasType);
+  Serial.println(" sensor");
+}
 
 void setup() {
-  // Serial port init for viewing printing output
   Serial.begin(115200);
-
-  // Change i2c address group
-  while (no2.changeI2cAddrGroup(7) == 0) {
-    Serial.println("IIC addr change fail!");
-    delay(1000);
-  }
-  Serial.println("IIC addr change success!");
-
-  // Sensor init, used to init serial port or I2C, depending on the communication mode currently
-  // used
-  while (!nh3.begin()) {
-    Serial.println("No Devices NH3 !");
-    delay(1000);
-  }
-  // Mode of obtaining data: the main controller needs to request the sensor for data
-  nh3.changeAcquireMode(nh3.PASSIVITY);
   delay(1000);
 
-  nh3.setTempCompensation(nh3.ON);
+  Serial.println("\n========================================");
+  Serial.println("DFRobot MultiGas Sensor Auto-Configure");
+  Serial.println("========================================");
+  Serial.println("\nScanning for sensors...\n");
 
-  Serial.println("The device nh3  0x7A is connected successfully!");
+  // Scan default group 6 addresses (0x74-0x77) for sensors
+  uint8_t defaultAddresses[] = {0x74, 0x75, 0x76, 0x77};
 
-  while (!co.begin()) {
-    Serial.println("No Devices CO !");
-    delay(1000);
+  for (uint8_t addr : defaultAddresses) {
+    if (initSensorAtAddress(addr)) {
+      if (sensorCount >= MAX_SENSORS) break;
+    }
   }
 
-  co.changeAcquireMode(co.PASSIVITY);
-  delay(1000);
-
-  co.setTempCompensation(co.ON);
-
-  Serial.println("The device CO  0x78 is connected successfully!");
-
-  while (!no2.begin()) {
-    Serial.println("No Devices NO2 !");
-    delay(1000);
+  if (sensorCount == 0) {
+    Serial.println("ERROR: No sensors detected!");
+    Serial.println("Please check I2C connections and sensor power.");
+    while (1) {
+      delay(1000);
+    }
   }
 
-  no2.changeAcquireMode(no2.PASSIVITY);
-  delay(1000);
+  Serial.print("\nFound ");
+  Serial.print(sensorCount);
+  Serial.println(" sensor(s)");
 
-  no2.setTempCompensation(no2.ON);
+  // Configure all detected sensors
+  Serial.println("\n========================================");
+  Serial.println("Configuring sensors...");
+  Serial.println("========================================");
 
-  Serial.println("The device NO2  0x7B is connected successfully!");
-
-  while (!o3.begin()) {
-    Serial.println("No Devices O3 !");
-    delay(1000);
+  for (int i = 0; i < sensorCount; i++) {
+    configureSensor(sensors[i]);
   }
 
-  o3.changeAcquireMode(o3.PASSIVITY);
-  delay(1000);
-
-  o3.setTempCompensation(o3.ON);
-
-  Serial.println("The device O3  0x79 is connected successfully!");
+  Serial.println("\n========================================");
+  Serial.println("Configuration complete!");
+  Serial.println("========================================\n");
 }
 
 void loop() {
-  String gastypeNH3 = nh3.queryGasType();
-  /**
-   *Fill in the parameter readGasConcentration() with the type of gas to be obtained and print
-   *The current gas concentration
-   *Print with 1s delay each time
-   */
-  Serial.print("Ambient ");
-  Serial.print(gastypeNH3);
-  Serial.print(" concentration is: ");
-  Serial.print(nh3.readGasConcentrationPPM());
-  if (gastypeNH3 == "O2")
-    Serial.println(" %vol");
-  else
-    Serial.println(" PPM");
-  Serial.println();
-  delay(1000);
+  for (int i = 0; i < sensorCount; i++) {
+    if (sensors[i].initialized) {
+      Serial.print(sensors[i].gasType);
+      Serial.print(" (0x");
+      Serial.print(sensors[i].addr, HEX);
+      Serial.print("): ");
+      Serial.print(sensors[i].sensor->readGasConcentrationPPM());
 
-  String gastypeCO = co.queryGasType();
-  /**
-   *Fill in the parameter readGasConcentration() with the type of gas to be obtained and print
-   *The current gas concentration
-   *Print with 1s delay each time
-   */
-  Serial.print("Ambient ");
-  Serial.print(gastypeCO);
-  Serial.print(" concentration is: ");
-  Serial.print(co.readGasConcentrationPPM());
-  if (gastypeCO == "O2")
-    Serial.println(" %vol");
-  else
-    Serial.println(" PPM");
-  Serial.println();
-  delay(1000);
+      if (sensors[i].gasType == "O2") {
+        Serial.println(" %vol");
+      } else {
+        Serial.println(" PPM");
+      }
+    }
+  }
 
-  String gastypeNO2 = no2.queryGasType();
-  /**
-   *Fill in the parameter readGasConcentration() with the type of gas to be obtained and print
-   *The current gas concentration
-   *Print with 1s delay each time
-   */
-  Serial.print("Ambient ");
-  Serial.print(gastypeNO2);
-  Serial.print(" concentration is: ");
-  Serial.print(no2.readGasConcentrationPPM());
-  if (gastypeNO2 == "O2")
-    Serial.println(" %vol");
-  else
-    Serial.println(" PPM");
   Serial.println();
-  delay(1000);
-
-  String gastypeO3 = o3.queryGasType();
-  /**
-   *Fill in the parameter readGasConcentration() with the type of gas to be obtained and print
-   *The current gas concentration
-   *Print with 1s delay each time
-   */
-  Serial.print("Ambient ");
-  Serial.print(gastypeO3);
-  Serial.print(" concentration is: ");
-  Serial.print(o3.readGasConcentrationPPM());
-  if (gastypeO3 == "O2")
-    Serial.println(" %vol");
-  else
-    Serial.println(" PPM");
-  Serial.println();
-  delay(1000);
+  delay(2000);
 }

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1291,7 +1291,9 @@ void Sensors::DFRobotNH3Read() {
   bool hasExternalTempSensor = dfrHasExternalTempSensor();
   float compensationTemp = hasExternalTempSensor ? temp : (dfrInternalTemp - toffset);
   nh3 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::NH3);
-  if (pres > 0.0) nh3 = dfrGasPressCompensation(nh3, pres);
+  if (hasExternalTempSensor && humi > 0.0f)
+    nh3 = dfrGasHumiCompensation(nh3, humi, DFRobot_GAS::NH3);
+  if (pres > 0.0) nh3 = dfrGasPressCompensation(nh3, pres); 
   unitRegister(UNIT::NH3);
   dataReady = true;
   if (!hasExternalTempSensor) {
@@ -1307,6 +1309,8 @@ void Sensors::DFRobotCORead() {
   bool hasExternalTempSensor = dfrHasExternalTempSensor();
   float compensationTemp = hasExternalTempSensor ? temp : (dfrInternalTemp - toffset);
   co = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::CO);
+  if (hasExternalTempSensor && humi > 0.0f)
+    co = dfrGasHumiCompensation(co, humi, DFRobot_GAS::CO);
   if (pres > 0.0) co = dfrGasPressCompensation(co, pres);
   unitRegister(UNIT::CO);
   dataReady = true;
@@ -1323,6 +1327,8 @@ void Sensors::DFRobotNO2Read() {
   bool hasExternalTempSensor = dfrHasExternalTempSensor();
   float compensationTemp = hasExternalTempSensor ? temp : (dfrInternalTemp - toffset);
   no2 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::NO2);
+  if (hasExternalTempSensor && humi > 0.0f)
+    no2 = dfrGasHumiCompensation(no2, humi, DFRobot_GAS::NO2);
   if (pres > 0.0) no2 = dfrGasPressCompensation(no2, pres);
   unitRegister(UNIT::NO2);
   dataReady = true;
@@ -1339,6 +1345,8 @@ void Sensors::DFRobotO3Read() {
   bool hasExternalTempSensor = dfrHasExternalTempSensor();
   float compensationTemp = hasExternalTempSensor ? temp : (dfrInternalTemp - toffset);
   o3 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::O3);
+  if (hasExternalTempSensor && humi > 0.0f)
+    o3 = dfrGasHumiCompensation(o3, humi, DFRobot_GAS::O3);
   if (pres > 0.0) o3 = dfrGasPressCompensation(o3, pres);
   unitRegister(UNIT::O3);
   dataReady = true;
@@ -2316,6 +2324,62 @@ float Sensors::dfrGasPressCompensation(float ppm, float pressure) {
   static const float STANDARD_PRESSURE_HPA = 1013.25f;
   if (pressure <= 0.0f) return ppm;
   return ppm * (STANDARD_PRESSURE_HPA / pressure);
+}
+
+/**
+ * @brief Humidity compensation for DFRobot electrochemical gas sensors.
+ *
+ * Electrochemical cells drift with relative humidity (cross-sensitivity),
+ * most noticeably for NO2 and NH3. DFRobot does NOT publish official RH
+ * coefficients, so by default this function is a NO-OP (coefficients = 0)
+ * and returns the input unchanged — it will not introduce noise.
+ *
+ * Once you have the SHT31 logging in parallel with the official reference
+ * station, derive real per-gas coefficients by regression and either fill
+ * them in below or define SLIB_DFR_HUMI_COMP with your fitted values.
+ *
+ * Model: ppm_out = (ppm / (1 + k_gain*(RH-REF))) - k_off*(RH-REF)
+ *
+ * @param ppm   Gas concentration after temperature compensation
+ * @param humidity  Relative humidity in % (from SHT31/BME280/etc.)
+ * @param gasType   DFRobot gas type constant (::CO, ::NH3, ::NO2, ::O3)
+ * @return Humidity-compensated gas concentration in PPM
+ */
+float Sensors::dfrGasHumiCompensation(float ppm, float humidity, uint8_t gasType) {
+  static const float REF_HUMI = 50.0f;  // factory reference RH (%)
+  if (humidity <= 0.0f || humidity > 100.0f) return ppm;
+
+  const float delta = humidity - REF_HUMI;
+
+  // Default coefficients = 0 (NO-OP). Replace with your regression results.
+  float kGain = 0.0f;  // sensitivity drift per %RH
+  float kOff = 0.0f;   // baseline drift per %RH
+
+  switch (gasType) {
+    case DFRobot_GAS::NH3:
+      // kGain = 0.0015f; kOff = 0.002f;   // example placeholders
+      break;
+    case DFRobot_GAS::NO2:
+      // kGain = 0.0010f; kOff = 0.001f;
+      break;
+    case DFRobot_GAS::O3:
+      // kGain = 0.0020f; kOff = 0.0015f;
+      break;
+    case DFRobot_GAS::CO:
+      // kGain = 0.0005f; kOff = 0.0f;
+      break;
+    default:
+      break;
+  }
+
+  if (kGain == 0.0f && kOff == 0.0f) return ppm;  // nothing to do
+
+  const float gainDivisor = 1.0f + kGain * delta;
+  const float scaled = (gainDivisor != 0.0f) ? (ppm / gainDivisor) : ppm;
+  const float compensated = scaled - kOff * delta;
+
+  if (compensated < 0.0f) return (scaled > 0.0f) ? scaled : 0.0f;
+  return compensated;
 }
 
 /// DFRobot GAS (CO) sensors init

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1293,7 +1293,7 @@ void Sensors::DFRobotNH3Read() {
   nh3 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::NH3);
   if (hasExternalTempSensor && humi > 0.0f)
     nh3 = dfrGasHumiCompensation(nh3, humi, DFRobot_GAS::NH3);
-  if (pres > 0.0) nh3 = dfrGasPressCompensation(nh3, pres); 
+  if (pres > 0.0) nh3 = dfrGasPressCompensation(nh3, pres);
   unitRegister(UNIT::NH3);
   dataReady = true;
   if (!hasExternalTempSensor) {
@@ -1309,8 +1309,7 @@ void Sensors::DFRobotCORead() {
   bool hasExternalTempSensor = dfrHasExternalTempSensor();
   float compensationTemp = hasExternalTempSensor ? temp : (dfrInternalTemp - toffset);
   co = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::CO);
-  if (hasExternalTempSensor && humi > 0.0f)
-    co = dfrGasHumiCompensation(co, humi, DFRobot_GAS::CO);
+  if (hasExternalTempSensor && humi > 0.0f) co = dfrGasHumiCompensation(co, humi, DFRobot_GAS::CO);
   if (pres > 0.0) co = dfrGasPressCompensation(co, pres);
   unitRegister(UNIT::CO);
   dataReady = true;
@@ -1345,8 +1344,7 @@ void Sensors::DFRobotO3Read() {
   bool hasExternalTempSensor = dfrHasExternalTempSensor();
   float compensationTemp = hasExternalTempSensor ? temp : (dfrInternalTemp - toffset);
   o3 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::O3);
-  if (hasExternalTempSensor && humi > 0.0f)
-    o3 = dfrGasHumiCompensation(o3, humi, DFRobot_GAS::O3);
+  if (hasExternalTempSensor && humi > 0.0f) o3 = dfrGasHumiCompensation(o3, humi, DFRobot_GAS::O3);
   if (pres > 0.0) o3 = dfrGasPressCompensation(o3, pres);
   unitRegister(UNIT::O3);
   dataReady = true;

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -617,6 +617,7 @@ class Sensors {
 
   float dfrGasTempCompensation(float rawPpm, float temperature, uint8_t gasType);
   float dfrGasPressCompensation(float ppm, float pressure);
+  float dfrGasHumiCompensation(float ppm, float humidity, uint8_t gasType);
   bool dfrHasExternalTempSensor() const;
 
   // UART sensors methods:


### PR DESCRIPTION
feat(dfrobot): add humidity compensation for electrochemical gas sensors

Add dfrGasHumiCompensation() to correct RH cross-sensitivity in the
DFRobot Gravity gas sensors (CO, NH3, NO2, O3), applied after temperature
compensation when an external T/H sensor (e.g. SHT31) is present.

Coefficients default to zero (no-op) since DFRobot does not publish
official RH characterization data; the function returns the input
unchanged until per-gas coefficients are derived empirically by
regression against a reference station. This keeps current behavior
intact while providing the structure for later calibration.

- Declare dfrGasHumiCompensation() in Sensors.hpp
- Implement it in Sensors.cpp with per-gas placeholder coefficients
- Apply RH compensation in DFRobotCORead/NH3Read/NO2Read/O3Read,
  guarded by external temp sensor presence and valid humidity

## Tests
Xiao s3 + nh3 + no2 + o3 + sps30 + sht31 + noise