### PR TITLE
Fix api timer geiger

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -59,6 +59,10 @@ build_flags =
 extends = esp32_common
 board = esp32-c3-devkitm-1
 build_src_filter = -<*> +<advanced_multivariable/>
+build_flags =
+ 	${env.build_flags}
+ 	-DARDUINO_USB_MODE=1
+ 	-DARDUINO_USB_CDC_ON_BOOT=1
 
 [env:esp32s2]
 extends = esp32_common
@@ -94,13 +98,3 @@ build_flags =
 extends = atmelsam_common
 build_src_filter = -<*> +<wio_terminal_basic/>
 
-; [env:lolin_c3_mini]
-; extends = esp32_common
-; board = lolin_c3_mini
-; build_src_filter = -<*> +<advanced_multivariable/>
-; upload_speed = 38400
-; monitor_speed = 115200
-; build_flags =
-; 	${env.build_flags}
-; 	-DARDUINO_USB_MODE=1
-; 	-DARDUINO_USB_CDC_ON_BOOT=1

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -1293,7 +1293,7 @@ void Sensors::DFRobotNH3Read() {
   nh3 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::NH3);
   if (hasExternalTempSensor && humi > 0.0f)
     nh3 = dfrGasHumiCompensation(nh3, humi, DFRobot_GAS::NH3);
-  if (pres > 0.0) nh3 = dfrGasPressCompensation(nh3, pres); 
+  if (pres > 0.0) nh3 = dfrGasPressCompensation(nh3, pres);
   unitRegister(UNIT::NH3);
   dataReady = true;
   if (!hasExternalTempSensor) {
@@ -1309,8 +1309,7 @@ void Sensors::DFRobotCORead() {
   bool hasExternalTempSensor = dfrHasExternalTempSensor();
   float compensationTemp = hasExternalTempSensor ? temp : (dfrInternalTemp - toffset);
   co = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::CO);
-  if (hasExternalTempSensor && humi > 0.0f)
-    co = dfrGasHumiCompensation(co, humi, DFRobot_GAS::CO);
+  if (hasExternalTempSensor && humi > 0.0f) co = dfrGasHumiCompensation(co, humi, DFRobot_GAS::CO);
   if (pres > 0.0) co = dfrGasPressCompensation(co, pres);
   unitRegister(UNIT::CO);
   dataReady = true;
@@ -1345,8 +1344,7 @@ void Sensors::DFRobotO3Read() {
   bool hasExternalTempSensor = dfrHasExternalTempSensor();
   float compensationTemp = hasExternalTempSensor ? temp : (dfrInternalTemp - toffset);
   o3 = dfrGasTempCompensation(rawPpm, compensationTemp, DFRobot_GAS::O3);
-  if (hasExternalTempSensor && humi > 0.0f)
-    o3 = dfrGasHumiCompensation(o3, humi, DFRobot_GAS::O3);
+  if (hasExternalTempSensor && humi > 0.0f) o3 = dfrGasHumiCompensation(o3, humi, DFRobot_GAS::O3);
   if (pres > 0.0) o3 = dfrGasPressCompensation(o3, pres);
   unitRegister(UNIT::O3);
   dataReady = true;

--- a/src/drivers/geiger.cpp
+++ b/src/drivers/geiger.cpp
@@ -52,9 +52,21 @@ GEIGER::GEIGER(int gpio, bool debug) {
 
   // attach interrupt routine to internal timer, to fire every 1000 ms
   // New ESP32 timer API uses frequency in Hz rather than timer number/prescaler.
+  // Support both old and new ESP32 Arduino timer APIs:
+  // - Older cores: timerBegin(uint32_t frequency), timerAttachInterrupt(hw_timer_t*, void(*)()), timerAlarm(...)
+  // - Newer cores: timerBegin(uint8_t, uint16_t, bool), timerAttachInterrupt(..., bool), timerAlarmWrite(), timerAlarmEnable()
+#if defined(MAIN_ESP32_HAL_TIMER_H_)
+  // New API
+  geiger_timer = timerBegin(0, 80, true);
+  timerAttachInterrupt(geiger_timer, &onGeigerTimer, true);
+  timerAlarmWrite(geiger_timer, 1000000, true); // 1000 ms periodic
+  timerAlarmEnable(geiger_timer);
+#else
+  // Old API
   geiger_timer = timerBegin(1000000);
   timerAttachInterrupt(geiger_timer, onGeigerTimer);
   timerAlarm(geiger_timer, 1000000, true, 1000000);  // 1000 ms periodic
+#endif
 #endif
 }
 

--- a/src/drivers/geiger.cpp
+++ b/src/drivers/geiger.cpp
@@ -53,13 +53,15 @@ GEIGER::GEIGER(int gpio, bool debug) {
   // attach interrupt routine to internal timer, to fire every 1000 ms
   // New ESP32 timer API uses frequency in Hz rather than timer number/prescaler.
   // Support both old and new ESP32 Arduino timer APIs:
-  // - Older cores: timerBegin(uint32_t frequency), timerAttachInterrupt(hw_timer_t*, void(*)()), timerAlarm(...)
-  // - Newer cores: timerBegin(uint8_t, uint16_t, bool), timerAttachInterrupt(..., bool), timerAlarmWrite(), timerAlarmEnable()
+  // - Older cores: timerBegin(uint32_t frequency), timerAttachInterrupt(hw_timer_t*, void(*)()),
+  // timerAlarm(...)
+  // - Newer cores: timerBegin(uint8_t, uint16_t, bool), timerAttachInterrupt(..., bool),
+  // timerAlarmWrite(), timerAlarmEnable()
 #if defined(MAIN_ESP32_HAL_TIMER_H_)
   // New API
   geiger_timer = timerBegin(0, 80, true);
   timerAttachInterrupt(geiger_timer, &onGeigerTimer, true);
-  timerAlarmWrite(geiger_timer, 1000000, true); // 1000 ms periodic
+  timerAlarmWrite(geiger_timer, 1000000, true);  // 1000 ms periodic
   timerAlarmEnable(geiger_timer);
 #else
   // Old API

--- a/src/drivers/geiger.cpp
+++ b/src/drivers/geiger.cpp
@@ -51,10 +51,10 @@ GEIGER::GEIGER(int gpio, bool debug) {
   attachInterrupt(digitalPinToInterrupt(gpio), GeigerTicISR, FALLING);
 
   // attach interrupt routine to internal timer, to fire every 1000 ms
-  geiger_timer = timerBegin(GEIGER_TIMER, 80, true);
-  timerAttachInterrupt(geiger_timer, &onGeigerTimer, true);
-  timerAlarmWrite(geiger_timer, 1000000, true);  // 1000 ms
-  timerAlarmEnable(geiger_timer);
+  // New ESP32 timer API uses frequency in Hz rather than timer number/prescaler.
+  geiger_timer = timerBegin(1000000);
+  timerAttachInterrupt(geiger_timer, onGeigerTimer);
+  timerAlarm(geiger_timer, 1000000, true, 1000000);  // 1000 ms periodic
 #endif
 }
 
@@ -104,10 +104,10 @@ bool GEIGER::read() {
 
 #ifdef CORE_DEBUG_LEVEL
   if (CORE_DEBUG_LEVEL >= 3) {
-    Serial.printf("-->[SLIB] tTOT:\t %i\r\n", tics_tot);
-    Serial.printf("-->[SLIB] tLEN:\t %i ", tics_len);
+    Serial.printf("-->[SLIB] tTOT:\t %lu\r\n", (unsigned long)tics_tot);
+    Serial.printf("-->[SLIB] tLEN:\t %lu ", (unsigned long)tics_len);
     Serial.println(ready ? "(ready)" : "(not ready)");
-    Serial.printf("-->[SLIB] tCPM:\t %i\r\n", tics_cpm);
+    Serial.printf("-->[SLIB] tCPM:\t %lu\r\n", (unsigned long)tics_cpm);
     Serial.printf("-->[SLIB] uSvh:\t %04.2f\r\n", uSvh);
   }
 #endif


### PR DESCRIPTION
Done:

ESP32S3 execution test
ESP32C3 execution test
ESP32S2 execution test
ESP32 execution test
Backward compatibility tests
Sensors tested: sps30 + sht31+ nh3 +o3 + no2 + noise

22:49:41.815 > -->[SLIB] UART detection msg : no data
22:49:41.815 > -->[SLIB] UART detection msg : no data
22:49:41.815 > [W][SLIB] GCJA5 UART msg : invalid header
22:49:41.815 > -->[SLIB] UART detection msg : no data
22:49:42.507 > -->[SLIB] UART detection msg : no data
22:49:42.507 > [W][SLIB] GCJA5 UART msg : invalid header
22:49:42.507 > -->[SLIB] UART sensors detected : 0
22:49:42.507 > -->[SLIB] I2C Wire started (custom) SDA:5, SCL:6
22:49:42.507 > -->[SLIB] I2C clock set to 100000 Hz
22:49:42.507 > -->[SLIB] attempt enable sensor : SCD30
22:49:42.507 > -->[SLIB] attempt enable sensor : GCJA5
22:49:42.507 > -->[SLIB] attempt enable sensor : SCD4X
22:49:43.009 > -->[SLIB] attempt enable sensor : SPS30
22:49:43.013 > -->[SLIB] SPS30 Serial number : 3A9C3D634FBAD919
22:49:43.016 > -->[SLIB] SPS30 product name : 00080000
22:49:43.019 > -->[SLIB] SPS30 firmware level : 2.2
22:49:43.019 > -->[SLIB] SPS30 Hardware level : 0
22:49:43.019 > -->[SLIB] SPS30 SHDLC protocol : 0.0
22:49:43.019 > -->[SLIB] SPS30 Library level : 1.4
22:49:44.017 > -->[SLIB] SPS30 Detected via : I2C
22:49:45.018 > -->[SLIB] SPS30 measurement : OK
22:49:45.018 > -->[SLIB] sensor registered : SPS30 :D
22:49:45.018 > -->[SLIB] attempt enable sensor : BMP280
22:49:45.018 > -->[SLIB] attempt enable sensor : BME280
22:49:45.019 > -->[SLIB] attempt enable sensor : BME680
22:49:45.019 > -->[SLIB] attempt enable sensor : AM232X
22:49:45.022 > -->[SLIB] attempt enable sensor : SHT31
22:49:45.034 > -->[SLIB] sensor registered : SHT31 :D
22:49:45.034 > -->[SLIB] attempt enable sensor : AHTXX
22:49:45.133 > -->[SLIB] attempt enable sensor : DFRCO
22:49:45.134 > [W][SLIB] DFRobot CO begin failed — I2C 0x78
22:49:45.134 > -->[SLIB] attempt enable sensor : DFRNH3
22:49:45.659 > -->[SLIB] sensor registered : DFRNH3 :D
22:49:45.659 > -->[SLIB] attempt enable sensor : DFRNO2
22:49:46.184 > -->[SLIB] sensor registered : DFRNO2 :D
22:49:46.184 > -->[SLIB] attempt enable sensor : DFRO3
22:49:46.709 > -->[SLIB] sensor registered : DFRO3 :D
22:49:46.709 > -->[SLIB] attempt enable sensor : SGP41
22:49:46.709 > -->[SLIB] sgp41 selftest error : 267
22:49:46.710 > -->[SLIB] Found device at: 0x08, reading identity...
22:49:46.718 > -->[SLIB] attempt enable sensor : NOISE
22:49:46.719 > -->[SLIB] sensor registered : NOISE :D
22:49:46.719 > -->[SLIB] Noise sensor detect: ok
22:49:46.719 > -->[SLIB] sensors count : 6 (SPS30,SHT31,DFRNH3,DFRNO2,DFRO3,NOISE,)
22:49:47.757 > -->[SLIB] SPS30 read : done!
22:49:47.801 > -->[SLIB] SHT31 read : done!
22:49:47.885 > -->[SLIB] sensors values : PM1:5.00 PM2.5:5.00 PM4:5.00 PM10:5.00 T:28.79 H:62.89 NH3:1.70 NO2:0.02 O3:0.03 Noise:70.43 NoiseAvg:70.43 NoisePeak:71.18 NoiseMin:70.43 NoiseAvgLegal:70.43 NoiseAvgLegalMax:71.18 Ld:0.00 Le:0.00 Ln:0.00 Lden:0.00
22:49:47.886 > -->[SLIB] sensors count : 6 (SPS30,SHT31,DFRNH3,DFRNO2,DFRO3,NOISE,)
22:49:47.886 > -->[SLIB] sensors units count : 19 (PM1,PM2.5,PM4,PM10,T,H,NH3,NO2,O3,Noise,NoiseAvg,NoisePeak,NoiseMin,NoiseAvgLegal,NoiseAvgLegalMax,Ld,Le,Ln,Lden,)
22:49:47.886 > ======= E X A M P L E T E S T =========
22:49:47.886 > -->[MAIN] Sensors detected count : 6
22:49:47.886 > -->[MAIN] Sensors units count : 19
22:49:47.886 > -->[MAIN] Sensors devices names : SPS30,SHT31,DFRNH3,DFRNO2,DFRO3,NOISE,
22:49:47.886 > -->[MAIN] Preview sensor values:
22:49:47.888 > -->[MAIN] PM1: 5.0 ug/m3
22:49:47.888 > -->[MAIN] PM2.5: 5.0 ug/m3
22:49:47.888 > -->[MAIN] PM4: 5.0 ug/m3
22:49:47.888 > -->[MAIN] PM10: 5.0 ug/m3
22:49:47.888 > -->[MAIN] T: 28.8 C
22:49:47.888 > -->[MAIN] H: 62.9 %
22:49:47.888 > -->[MAIN] NH3: 1.7 ppm
22:49:47.888 > -->[MAIN] NO2: 0.0 ppm
22:49:47.888 > -->[MAIN] O3: 0.0 ppm
22:49:47.888 > -->[MAIN] Noise: 70.4 dB
22:49:47.888 > -->[MAIN] NoiseAvg: 70.4 dB
22:49:47.888 > -->[MAIN] NoisePeak: 71.2 dB
22:49:47.888 > -->[MAIN] NoiseMin: 70.4 dB
22:49:47.888 > -->[MAIN] NoiseAvgLegal: 70.4 dB
22:49:47.888 > -->[MAIN] NoiseAvgLegalMax: 71.2 dB
22:49:47.888 > -->[MAIN] Ld: 0.0 dB
22:49:47.888 > -->[MAIN] Le: 0.0 dB
22:49:47.888 > -->[MAIN] Ln: 0.0 dB
22:49:47.888 > -->[MAIN] Lden: 0.0 dB
22:49:57.757 > -->[SLIB] SPS30 read : done!
22:49:57.799 > -->[SLIB] SHT31 read : done!
22:49:57.884 > -->[SLIB] sensors values : PM1:20.00 PM2.5:24.00 PM4:27.00 PM10:27.00 T:28.77 H:62.78 NH3:0.88 NO2:0.02 O3:0.03 Noise:70.43 NoiseAvg:70.43 NoisePeak:71.18 NoiseMin:70.43 NoiseAvgLegal:70.43 NoiseAvgLegalMax:71.18 Ld:0.00 Le:0.00 Ln:0.00 Lden:0.00
22:49:57.886 > -->[SLIB] sensors count : 6 (SPS30,SHT31,DFRNH3,DFRNO2,DFRO3,NOISE,)
22:49:57.886 > -->[SLIB] sensors units count : 19 (PM1,PM2.5,PM4,PM10,T,H,NH3,NO2,O3,Noise,NoiseAvg,NoisePeak,NoiseMin,NoiseAvgLegal,NoiseAvgLegalMax,Ld,Le,Ln,Lden,)