### PR TITLE
Fix/issue 232 dfrobot

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ monitor_filters =
 	time
 lib_deps = ${commonlibs.lib_deps}
 build_flags = 
-	-D CORE_DEBUG_LEVEL=1
+	-D CORE_DEBUG_LEVEL=0
 	-D ARDUINO_ESP32_DEV=1
 	-Wall
 	-Wextra

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -8,15 +8,7 @@
 #define SLIB_I2C_CLOCK_HZ 100000
 #endif
 
-static void dfrGasBeginFailed(const char *gasName, uint8_t i2cAddr) {
-#ifdef CORE_DEBUG_LEVEL
-  if (CORE_DEBUG_LEVEL > 0) {
-    Serial.printf("[W][SLIB] DFRobot %s begin failed — I2C 0x%02X\r\n", gasName, i2cAddr);
-  }
-#else
-  Serial.printf("[W][SLIB] DFRobot %s begin failed — I2C 0x%02X\r\n", gasName, i2cAddr);
-#endif
-}
+
 
 // Units and sensors registers
 
@@ -2378,7 +2370,10 @@ void Sensors::DFRobotCOInit() {
   dfrCO.changeAcquireMode(dfrCO.PASSIVITY);
   delay(500);  // Required for PASSIVITY mode to stabilize (see DFRobot example)
   // Disable internal compensation: we apply our own using external T/P sensors
-  dfrCO.setTempCompensation(dfrCO.OFF);
+  if (dfrHasExternalTempSensor())
+    dfrCO.setTempCompensation(dfrCO.ON);
+  else
+    dfrCO.setTempCompensation(dfrCO.OFF);
   sensorRegister(SENSORS::SDFRCO);
 }
 
@@ -2391,7 +2386,10 @@ void Sensors::DFRobotNH3Init() {
   dfrNH3.changeAcquireMode(dfrNH3.PASSIVITY);
   delay(500);  // Required for PASSIVITY mode to stabilize (see DFRobot example)
   // Disable internal compensation: we apply our own using external T/P sensors
-  dfrNH3.setTempCompensation(dfrNH3.OFF);
+  if (dfrHasExternalTempSensor())
+    dfrNH3.setTempCompensation(dfrNH3.ON);
+  else
+    dfrNH3.setTempCompensation(dfrNH3.OFF);
   sensorRegister(SENSORS::SDFRNH3);
 }
 
@@ -2404,7 +2402,10 @@ void Sensors::DFRobotNO2Init() {
   dfrNO2.changeAcquireMode(dfrNO2.PASSIVITY);
   delay(500);  // Required for PASSIVITY mode to stabilize (see DFRobot example)
   // Disable internal compensation: we apply our own using external T/P sensors
-  dfrNO2.setTempCompensation(dfrNO2.OFF);
+  if (dfrHasExternalTempSensor())
+    dfrNO2.setTempCompensation(dfrNO2.ON);
+  else
+    dfrNO2.setTempCompensation(dfrNO2.OFF);
   sensorRegister(SENSORS::SDFRNO2);
 }
 
@@ -2417,7 +2418,10 @@ void Sensors::DFRobotO3Init() {
   dfrO3.changeAcquireMode(dfrO3.PASSIVITY);
   delay(500);  // Required for PASSIVITY mode to stabilize (see DFRobot example)
   // Disable internal compensation: we apply our own using external T/P sensors
-  dfrO3.setTempCompensation(dfrO3.OFF);
+  if (dfrHasExternalTempSensor())
+    dfrO3.setTempCompensation(dfrO3.ON);
+  else
+    dfrO3.setTempCompensation(dfrO3.OFF);
   sensorRegister(SENSORS::SDFRO3);
 }
 

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -8,8 +8,6 @@
 #define SLIB_I2C_CLOCK_HZ 100000
 #endif
 
-
-
 // Units and sensors registers
 
 #define X(unit, symbol, name) symbol,

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -9,7 +9,13 @@
 #endif
 
 static void dfrGasBeginFailed(const char *gasName, uint8_t i2cAddr) {
+#ifdef CORE_DEBUG_LEVEL
+  if (CORE_DEBUG_LEVEL > 0) {
+    Serial.printf("[W][SLIB] DFRobot %s begin failed — I2C 0x%02X\r\n", gasName, i2cAddr);
+  }
+#else
   Serial.printf("[W][SLIB] DFRobot %s begin failed — I2C 0x%02X\r\n", gasName, i2cAddr);
+#endif
 }
 
 // Units and sensors registers
@@ -2367,10 +2373,7 @@ float Sensors::dfrGasHumiCompensation(float ppm, float humidity, uint8_t gasType
 void Sensors::DFRobotCOInit() {
   sensorAnnounce(SENSORS::SDFRCO);
   dfrCO = DFRobot_GAS_I2C(&Wire, DFROBOT_CO_I2C_ADDR);
-  if (!dfrCO.begin()) {
-    dfrGasBeginFailed("CO", DFROBOT_CO_I2C_ADDR);
-    return;
-  }
+  if (!dfrCO.begin()) return;
   // Mode of obtaining data: the main controller needs to request the sensor for data
   dfrCO.changeAcquireMode(dfrCO.PASSIVITY);
   delay(500);  // Required for PASSIVITY mode to stabilize (see DFRobot example)
@@ -2383,10 +2386,7 @@ void Sensors::DFRobotCOInit() {
 void Sensors::DFRobotNH3Init() {
   sensorAnnounce(SENSORS::SDFRNH3);
   dfrNH3 = DFRobot_GAS_I2C(&Wire, DFROBOT_NH3_I2C_ADDR);
-  if (!dfrNH3.begin()) {
-    dfrGasBeginFailed("NH3", DFROBOT_NH3_I2C_ADDR);
-    return;
-  }
+  if (!dfrNH3.begin()) return;
   // Mode of obtaining data: the main controller needs to request the sensor for data
   dfrNH3.changeAcquireMode(dfrNH3.PASSIVITY);
   delay(500);  // Required for PASSIVITY mode to stabilize (see DFRobot example)
@@ -2399,10 +2399,7 @@ void Sensors::DFRobotNH3Init() {
 void Sensors::DFRobotNO2Init() {
   sensorAnnounce(SENSORS::SDFRNO2);
   dfrNO2 = DFRobot_GAS_I2C(&Wire, DFROBOT_NO2_I2C_ADDR);
-  if (!dfrNO2.begin()) {
-    dfrGasBeginFailed("NO2", DFROBOT_NO2_I2C_ADDR);
-    return;
-  }
+  if (!dfrNO2.begin()) return;
   // Mode of obtaining data: the main controller needs to request the sensor for data
   dfrNO2.changeAcquireMode(dfrNO2.PASSIVITY);
   delay(500);  // Required for PASSIVITY mode to stabilize (see DFRobot example)
@@ -2415,10 +2412,7 @@ void Sensors::DFRobotNO2Init() {
 void Sensors::DFRobotO3Init() {
   sensorAnnounce(SENSORS::SDFRO3);
   dfrO3 = DFRobot_GAS_I2C(&Wire, DFROBOT_O3_I2C_ADDR);
-  if (!dfrO3.begin()) {
-    dfrGasBeginFailed("O3", DFROBOT_O3_I2C_ADDR);
-    return;
-  }
+  if (!dfrO3.begin()) return;
   // Mode of obtaining data: the main controller needs to request the sensor for data
   dfrO3.changeAcquireMode(dfrO3.PASSIVITY);
   delay(500);  // Required for PASSIVITY mode to stabilize (see DFRobot example)


### PR DESCRIPTION
Descripción

Suprime los mensajes de DFRobot cuando el sensor no está presente y [CORE_DEBUG_LEVEL=0]

Mantiene el anuncio de sensor solo si el sensor DFRobot responde correctamente.
Activa la compensación de temperatura interna de DFRobot solo cuando hay un sensor de temperatura externo válido presente.

Corrige el comportamiento para que el sensor se registre solo al detectarlo, en línea con el comportamiento de SHT31.
Detalles

Archivo principal afectado: [Sensors.cpp]
Se revisó y corrigió la inicialización de los sensores DFRobot CO, NH3, NO2 y O3.
Se limpiaron mensajes innecesarios en [platformio.ini] y se dejó la configuración correcta de [common].
Verificación

Compilación verificada en PlatformIO.
Cambios listos en la rama fix/issue-232-dfrobot.
Issue
Resuelve:#232